### PR TITLE
refactor: use number(5000) in path()

### DIFF
--- a/apps/librelingo_fakes/librelingo_fakes/fakes.py
+++ b/apps/librelingo_fakes/librelingo_fakes/fakes.py
@@ -287,7 +287,7 @@ def customize(fake, **kwargs):
 
 
 def path():
-    return Path(f"./path{random.randint(0, 5000)}")
+    return Path(f"./path{number(5000)}")
 
 
 def get_fake_skill(introduction=None):


### PR DESCRIPTION
## Description

I applied the function [`fakes.number`](https://github.com/LibreLingo/LibreLingo/blob/f866381521f2e118f2ec3a0b12cba94316261a7b/apps/librelingo_fakes/librelingo_fakes/fakes.py#L270) in [`fakes.path`](https://github.com/LibreLingo/LibreLingo/blob/f866381521f2e118f2ec3a0b12cba94316261a7b/apps/librelingo_fakes/librelingo_fakes/fakes.py#L289).

This has been [already](https://github.com/LibreLingo/LibreLingo/pull/1955/commits/930254162b53ed264acf58d80c5ae6745030d6b8) done, but I think it was lost while some merge conflict resolving.