### PR TITLE
chore: alias 'yarn web cypress' as 'yarn cypress'

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@librelingo/monorepo",
   "private": true,
   "scripts": {
+    "cypress": "yarn web cypress",
     "export:production": "yarn web installAllExternalCourses && yarn exportAllCourses && yarn web export && yarn docs:build && mv ./apps/web/__sapper__/ . && poetry run python apps/tools/librelingo_tools/generate.py --courses ./config/courses.json --outdir ./__sapper__/export/course-tools-legacy",
     "export": "yarn web export && mv ./apps/web/__sapper__/ .",
     "deploy": "echo 'librelingo.app' > __sapper__/export/CNAME && gh-pages -d __sapper__/export",


### PR DESCRIPTION
This way, a new cypress config cannot be accidentally created by running

```bash
yarn cypress open
```

also, it's a shortcut :smile_cat: 