### PR TITLE
chore(pylint): remove trailing unused-argument commented pylint rule

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -88,7 +88,6 @@ disable=raw-checker-failed,
         invalid-name,  # TODO: enable
         missing-function-docstring,  # TODO: enable
         redefined-outer-name,  # TODO: enable
-        # unused-argument,  # TODO: enable in files as well
         missing-class-docstring,  # TODO: enable
         too-many-public-methods,  # TODO: enable
         unspecified-encoding,  # TODO: enable


### PR DESCRIPTION
removed trailing pylint commented rule