### PR TITLE
refactor(tests): add test_yaml_loader_load_skills.py

### DIFF
--- a/apps/librelingo_audios/tests/test_update_audios.py
+++ b/apps/librelingo_audios/tests/test_update_audios.py
@@ -1,4 +1,3 @@
-# pylint: disable=unused-argument
 from librelingo_fakes import fakes
 from librelingo_types import Settings, AudioSettings, TextToSpeechSettings
 

--- a/apps/librelingo_json_export/tests/test_cli.py
+++ b/apps/librelingo_json_export/tests/test_cli.py
@@ -1,4 +1,3 @@
-# pylint: disable=unused-argument
 import os
 import pytest
 

--- a/apps/librelingo_json_export/tests/test_export_course.py
+++ b/apps/librelingo_json_export/tests/test_export_course.py
@@ -16,7 +16,7 @@ def mock_export_course_data(mocker):
 
 def test_calls__export_course_data_with_correct_value(
     fs, export_path, mock_export_course_data
-):  # pylint:disable=invalid-name
+):
     export_course(export_path, fakes.course1)
     mock_export_course_data.assert_called_with(export_path, fakes.course1, None)
 
@@ -28,6 +28,6 @@ def mock_export_course_skills(mocker):
 
 def test_calls__export_course_skills_with_correct_value(
     fs, export_path, mock_export_course_skills
-):  # pylint:disable=invalid-name
+):
     export_course(export_path, fakes.course1)
     mock_export_course_skills.assert_called_with(export_path, fakes.course1, None)

--- a/apps/librelingo_json_export/tests/test_export_course.py
+++ b/apps/librelingo_json_export/tests/test_export_course.py
@@ -1,4 +1,3 @@
-# pylint: disable=unused-argument
 import pytest
 
 from librelingo_json_export.export import export_course

--- a/apps/librelingo_json_export/tests/test_export_course_data.py
+++ b/apps/librelingo_json_export/tests/test_export_course_data.py
@@ -13,7 +13,7 @@ def export_path():
     return fakes.path()
 
 
-def test_creates_the_correct_file(fs, export_path):  # pylint:disable=invalid-name
+def test_creates_the_correct_file(fs, export_path):
     _export_course_data(export_path, fakes.course1)
     assert os.path.exists(export_path / "courseData.json")
 
@@ -25,7 +25,7 @@ def mock_get_course_data(mocker):
 
 def test_calls__get_course_data_with_correct_value(
     fs, export_path, mock_get_course_data
-):  # pylint:disable=invalid-name
+):
     mock_get_course_data.return_value = []
     _export_course_data(export_path, fakes.course1)
     mock_get_course_data.assert_called_with(fakes.course1)
@@ -41,7 +41,7 @@ def test_writes_correct_value_into_json_file(
         assert json.loads(f.read()) == fake_course_data
 
 
-def test_assert_logs_correctly(caplog, fs, export_path):  # pylint:disable=invalid-name
+def test_assert_logs_correctly(caplog, fs, export_path):
     with caplog.at_level(logging.INFO, logger="librelingo_json_export"):
         course_name = "Animals"
         target_name = "English"

--- a/apps/librelingo_json_export/tests/test_export_course_data.py
+++ b/apps/librelingo_json_export/tests/test_export_course_data.py
@@ -31,9 +31,7 @@ def test_calls__get_course_data_with_correct_value(
     mock_get_course_data.assert_called_with(fakes.course1)
 
 
-def test_writes_correct_value_into_json_file(
-    fs, export_path, mock_get_course_data
-):  # pylint:disable=invalid-name
+def test_writes_correct_value_into_json_file(fs, export_path, mock_get_course_data):
     fake_course_data = {"fake_course_data": 1000}
     mock_get_course_data.return_value = fake_course_data
     _export_course_data(export_path, fakes.course1)

--- a/apps/librelingo_json_export/tests/test_export_course_data.py
+++ b/apps/librelingo_json_export/tests/test_export_course_data.py
@@ -1,4 +1,3 @@
-# pylint: disable=unused-argument
 import os
 import json
 import logging

--- a/apps/librelingo_json_export/tests/test_export_course_skills.py
+++ b/apps/librelingo_json_export/tests/test_export_course_skills.py
@@ -1,4 +1,3 @@
-# pylint: disable=unused-argument
 import pytest
 
 from librelingo_json_export.export import _export_course_skills

--- a/apps/librelingo_json_export/tests/test_export_course_skills.py
+++ b/apps/librelingo_json_export/tests/test_export_course_skills.py
@@ -15,9 +15,7 @@ def mock_export_skill(mocker):
     return mocker.patch("librelingo_json_export.export._export_skill")
 
 
-def test_exports_all_skills(
-    mocker, fs, export_path, mock_export_skill
-):  # pylint:disable=invalid-name
+def test_exports_all_skills(mocker, fs, export_path, mock_export_skill):
     _, fake_skill_1 = fakes.get_fake_skill()
     _, fake_skill_2 = fakes.get_fake_skill()
     _, fake_skill_3 = fakes.get_fake_skill()

--- a/apps/librelingo_json_export/tests/test_export_skill.py
+++ b/apps/librelingo_json_export/tests/test_export_skill.py
@@ -1,4 +1,3 @@
-# pylint: disable=unused-argument
 import os
 import json
 import logging

--- a/apps/librelingo_json_export/tests/test_export_skill.py
+++ b/apps/librelingo_json_export/tests/test_export_skill.py
@@ -13,13 +13,13 @@ def export_path():
     return fakes.path()
 
 
-def test_creates_the_challenges_file(fs, export_path):  # pylint:disable=invalid-name
+def test_creates_the_challenges_file(fs, export_path):
     random_name, fake_skill = fakes.get_fake_skill()
     _export_skill(export_path, fake_skill, fakes.course1)
     assert os.path.exists(export_path / "challenges" / f"animals-{random_name}.json")
 
 
-def test_creates_the_introduction_file(fs, export_path):  # pylint:disable=invalid-name
+def test_creates_the_introduction_file(fs, export_path):
     fake_name = str(fakes.fake_value())
     introduction = f"# *Hello* (https://example.com)[_{fake_name}_]!"
     random_name, fake_skill = fakes.get_fake_skill(introduction=introduction)
@@ -33,7 +33,7 @@ def test_creates_the_introduction_file(fs, export_path):  # pylint:disable=inval
 
 def test_does_not_create_an_introduction_file_if_theres_no_introduction(
     fs, export_path
-):  # pylint:disable=invalid-name
+):
     random_name, fake_skill = fakes.get_fake_skill()
     _export_skill(export_path, fake_skill, fakes.course1)
     assert not os.path.exists(
@@ -46,17 +46,13 @@ def mock_get_skill_data(mocker):
     return mocker.patch("librelingo_json_export.export._get_skill_data")
 
 
-def test_calls__get_skill_data_with_correct_value(
-    fs, export_path, mock_get_skill_data
-):  # pylint:disable=invalid-name
+def test_calls__get_skill_data_with_correct_value(fs, export_path, mock_get_skill_data):
     mock_get_skill_data.return_value = []
     _export_skill(export_path, fakes.skillWithPhraseAndWord, fakes.course1)
     mock_get_skill_data.assert_called_with(fakes.skillWithPhraseAndWord, fakes.course1)
 
 
-def test_writes_correct_value_into_json_file(
-    fs, export_path, mock_get_skill_data
-):  # pylint:disable=invalid-name
+def test_writes_correct_value_into_json_file(fs, export_path, mock_get_skill_data):
     fake_skill_data = {"fake_skill_data": 1000}
     mock_get_skill_data.return_value = fake_skill_data
     _export_skill(export_path, fakes.skillWithPhraseAndWord, fakes.course1)
@@ -64,7 +60,7 @@ def test_writes_correct_value_into_json_file(
         assert json.loads(masculine_file.read()) == fake_skill_data
 
 
-def test_assert_logs_correctly(fs, caplog, export_path):  # pylint:disable=invalid-name
+def test_assert_logs_correctly(fs, caplog, export_path):
     with caplog.at_level(logging.INFO, logger="librelingo_json_export"):
         _, fake_skill = fakes.get_fake_skill()
         _export_skill(export_path, fake_skill, fakes.course1)

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
@@ -1,4 +1,3 @@
-# pylint: disable=unused-argument
 import os
 import re
 from pathlib import Path

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
@@ -529,29 +529,6 @@ class LoadModulesTestCase(TestCase):
         load_module.assert_called_with(Path("foo/bar"), fakes.course1)
 
 
-class TestLoadSkills(TestCase):
-    @patch("librelingo_yaml_loader.yaml_loader._load_skill")
-    def test_returns_correct_value(self, load_skill):
-        load_skill.return_value = fakes.fake_value()
-        self.assertEqual(
-            _load_skills("foo", ["bar"], fakes.course1), [load_skill.return_value]
-        )
-
-    @patch("librelingo_yaml_loader.yaml_loader._load_skill")
-    def test_handles_every_module(self, load_skill):
-        load_skill.return_value = fakes.fake_value()
-        self.assertEqual(
-            _load_skills("foo", ["bar", "baz"], fakes.course1),
-            [load_skill.return_value] * 2,
-        )
-
-    @patch("librelingo_yaml_loader.yaml_loader._load_skill")
-    def test_calls_load_skills_with_correct_arguments(self, load_skill):
-        # pylint: disable=no-self-use
-        _load_skills("foo", ["bar.yaml"], fakes.course1)
-        load_skill.assert_called_with(Path("foo/skills/bar.yaml"), fakes.course1)
-
-
 class TestLoadSkill(YamlImportTestCase):
     def get_fake_skill_yaml(self, **kwargs):
         # pylint: disable=no-self-use

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
@@ -730,6 +730,7 @@ def test_load_module_complains_missing_module_name(load_yaml):
 
 @patch("librelingo_yaml_loader.yaml_loader._load_yaml")
 def test_load_skills_complains_missing_skills(load_yaml):
+    # pylint: disable=unused-argument
     random_path = fakes.path()
     expected_error = (
         f'Module file "{random_path}/module.yaml" needs to have a list of skills'

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_convert_phrases.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_convert_phrases.py
@@ -19,7 +19,6 @@ def mock_convert_phrase(mocker):
 
 
 def test_converts_every_word(mock_convert_phrase):
-    # pylint: disable=unused-argument
     # mock_convert_phrase is needed here becasue
     # _convert_phrase crashes for input None
     raw_words = [None] * fakes.number()

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_convert_words.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_convert_words.py
@@ -19,7 +19,6 @@ def mock_convert_word(mocker):
 
 
 def test_converts_every_word(mock_convert_word):
-    # pylint: disable=unused-argument
     raw_words = [None] * fakes.number()
     assert len(_convert_words(raw_words)) == len(raw_words)
 

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py
@@ -15,13 +15,11 @@ def mock_load_skill(mocker):
 
 
 def test_returns_correct_value(fs, mock_load_skill):
-    # pylint: disable=unused-argument
     mock_load_skill.return_value = fakes.fake_value()
     assert _load_skills("foo", ["bar"], fakes.course1) == [mock_load_skill.return_value]
 
 
 def test_handles_every_module(fs, mock_load_skill):
-    # pylint: disable=unused-argument
     mock_load_skill.return_value = fakes.fake_value()
     assert (
         _load_skills("foo", ["bar", "baz"], fakes.course1)
@@ -30,6 +28,5 @@ def test_handles_every_module(fs, mock_load_skill):
 
 
 def test_calls_load_skills_with_correct_arguments(fs, mock_load_skill):
-    # pylint: disable=unused-argument
     _load_skills("foo", ["bar.yaml"], fakes.course1)
     mock_load_skill.assert_called_with(Path("foo/skills/bar.yaml"), fakes.course1)

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py
@@ -2,10 +2,9 @@
 this file contains tests of the funcion
 librelingo_yaml_loader.yaml_loader._load_skills
 """
-
+from pathlib import Path
 import pytest
 
-from pathlib import Path
 from librelingo_yaml_loader.yaml_loader import _load_skills
 from librelingo_fakes import fakes
 

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py
@@ -16,11 +16,13 @@ def mock_load_skill(mocker):
 
 
 def test_returns_correct_value(fs, mock_load_skill):
+    # pylint: disable=unused-argument
     mock_load_skill.return_value = fakes.fake_value()
     assert _load_skills("foo", ["bar"], fakes.course1) == [mock_load_skill.return_value]
 
 
 def test_handles_every_module(fs, mock_load_skill):
+    # pylint: disable=unused-argument
     mock_load_skill.return_value = fakes.fake_value()
     assert (
         _load_skills("foo", ["bar", "baz"], fakes.course1)
@@ -29,5 +31,6 @@ def test_handles_every_module(fs, mock_load_skill):
 
 
 def test_calls_load_skills_with_correct_arguments(fs, mock_load_skill):
+    # pylint: disable=unused-argument
     _load_skills("foo", ["bar.yaml"], fakes.course1)
     mock_load_skill.assert_called_with(Path("foo/skills/bar.yaml"), fakes.course1)

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py
@@ -1,0 +1,33 @@
+"""
+this file contains tests of the funcion
+librelingo_yaml_loader.yaml_loader._load_skills
+"""
+
+import pytest
+
+from pathlib import Path
+from librelingo_yaml_loader.yaml_loader import _load_skills
+from librelingo_fakes import fakes
+
+
+@pytest.fixture
+def mock_load_skill(mocker):
+    yield mocker.patch("librelingo_yaml_loader.yaml_loader._load_skill")
+
+
+def test_returns_correct_value(fs, mock_load_skill):
+    mock_load_skill.return_value = fakes.fake_value()
+    assert _load_skills("foo", ["bar"], fakes.course1) == [mock_load_skill.return_value]
+
+
+def test_handles_every_module(fs, mock_load_skill):
+    mock_load_skill.return_value = fakes.fake_value()
+    assert (
+        _load_skills("foo", ["bar", "baz"], fakes.course1)
+        == [mock_load_skill.return_value] * 2
+    )
+
+
+def test_calls_load_skills_with_correct_arguments(fs, mock_load_skill):
+    _load_skills("foo", ["bar.yaml"], fakes.course1)
+    mock_load_skill.assert_called_with(Path("foo/skills/bar.yaml"), fakes.course1)


### PR DESCRIPTION
Continuation of [rewriting all of the tests using `pytest`](https://github.com/kantord/LibreLingo/pull/1912#issuecomment-1002282919).

- I moved the tests from the class [`TestLoadSkills`](https://github.com/LibreLingo/LibreLingo/blob/ec8fedc05700869143312cf2cee3e74a263c88b6/apps/librelingo_yaml_loader/tests/test_yaml_loader.py#L533) to the file [`test_yaml_loader_load_skills.py`](https://github.com/vil02/LibreLingo/blob/eff53f9f9d61457f3a801677d38149d745d1013e/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py),
- I removed suppression of the `pylint` warnings `unused-argument` and `invalid-name` (cf. #2043 and https://github.com/LibreLingo/LibreLingo/pull/2042#discussion_r804458049)