### PR TITLE
refactor(tests): add test_yaml_loader_load_modules.py

### DIFF
--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
@@ -2,7 +2,6 @@ import os
 import re
 from pathlib import Path
 from unittest.mock import Mock, patch
-from unittest import TestCase
 import pytest
 from pyfakefs.fake_filesystem_unittest import TestCase as FakeFsTestCase  # type: ignore
 from librelingo_types.data_types import Settings

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
@@ -22,7 +22,6 @@ from librelingo_yaml_loader.yaml_loader import (
     load_course,
     _convert_license,
     _load_module,
-    _load_modules,
     _load_skills,
     _load_skill,
 )
@@ -504,29 +503,6 @@ class TestLoadModuleMeta(YamlImportTestCase):
             ],
             fakes.course1,
         )
-
-
-class LoadModulesTestCase(TestCase):
-    @patch("librelingo_yaml_loader.yaml_loader._load_module")
-    def test_returns_correct_value(self, load_module):
-        load_module.return_value = fakes.fake_value()
-        self.assertEqual(
-            _load_modules("foo", ["bar"], fakes.course1), [load_module.return_value]
-        )
-
-    @patch("librelingo_yaml_loader.yaml_loader._load_module")
-    def test_handles_every_module(self, load_module):
-        load_module.return_value = fakes.fake_value()
-        self.assertEqual(
-            _load_modules("foo", ["bar", "baz"], fakes.course1),
-            [load_module.return_value] * 2,
-        )
-
-    @patch("librelingo_yaml_loader.yaml_loader._load_module")
-    def test_calls_load_modules_with_correct_arguments(self, load_module):
-        # pylint: disable=no-self-use
-        _load_modules("foo", ["bar"], fakes.course1)
-        load_module.assert_called_with(Path("foo/bar"), fakes.course1)
 
 
 class TestLoadSkill(YamlImportTestCase):

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_modules.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_modules.py
@@ -16,14 +16,16 @@ def mock_load_module(mocker):
 
 def test_returns_correct_value(mock_load_module):
     mock_load_module.return_value = fakes.fake_value()
-    assert _load_modules("foo", ["bar"], fakes.course1) == [load_module.return_value]
+    assert _load_modules("foo", ["bar"], fakes.course1) == [
+        mock_load_module.return_value
+    ]
 
 
 def test_handles_every_module(mock_load_module):
     mock_load_module.return_value = fakes.fake_value()
     assert (
         _load_modules("foo", ["bar", "baz"], fakes.course1)
-        == [load_module.return_value] * 2
+        == [mock_load_module.return_value] * 2
     )
 
 

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_modules.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_modules.py
@@ -1,0 +1,32 @@
+"""
+this file contains tests of the funcion
+librelingo_yaml_loader.yaml_loader._load_modules
+"""
+from pathlib import Path
+import pytest
+
+from librelingo_yaml_loader.yaml_loader import _load_modules
+from librelingo_fakes import fakes
+
+
+@pytest.fixture
+def mock_load_module(mocker):
+    yield mocker.patch("librelingo_yaml_loader.yaml_loader._load_module")
+
+
+def test_returns_correct_value(mock_load_module):
+    mock_load_module.return_value = fakes.fake_value()
+    assert _load_modules("foo", ["bar"], fakes.course1) == [load_module.return_value]
+
+
+def test_handles_every_module(mock_load_module):
+    mock_load_module.return_value = fakes.fake_value()
+    assert (
+        _load_modules("foo", ["bar", "baz"], fakes.course1)
+        == [load_module.return_value] * 2
+    )
+
+
+def test_calls_load_modules_with_correct_arguments(mock_load_module):
+    _load_modules("foo", ["bar"], fakes.course1)
+    mock_load_module.assert_called_with(Path("foo/bar"), fakes.course1)


### PR DESCRIPTION
Continuation of [rewriting all of the tests using `pytest`](https://github.com/kantord/LibreLingo/pull/1912#issuecomment-1002282919).

I moved the tests from the class [`LoadModulesTestCase`](https://github.com/LibreLingo/LibreLingo/blob/de283649c8e8722aea20407682f2c5fa5169704a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py#L509) to the file [test_yaml_loader_load_modules.py](https://github.com/vil02/LibreLingo/blob/6783c3ed38dc3d2aec7e3bafbd31e0da554624a5/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_modules.py).