### PR TITLE
reorganize python imports 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ __sapper__
 profile.dat
 /apps/librelingo_json_export/profile.png
 /apps/*/poetry.lock
+.vscode/

--- a/apps/librelingo_json_export/librelingo_json_export/challenge_types.py
+++ b/apps/librelingo_json_export/librelingo_json_export/challenge_types.py
@@ -1,15 +1,12 @@
 import editdistance  # type: ignore
-
-
-from librelingo_utils import (
-    get_dumb_opaque_id,
-    audio_id,
-    remove_control_characters_for_display,
-    clean_word,
-    iterate_phrases,
-)
-
 from librelingo_types import Course, Word
+from librelingo_utils import (
+    audio_id,
+    clean_word,
+    get_dumb_opaque_id,
+    iterate_phrases,
+    remove_control_characters_for_display,
+)
 
 from .dictionary import _define_words_in_sentence
 

--- a/apps/librelingo_json_export/librelingo_json_export/challenges.py
+++ b/apps/librelingo_json_export/librelingo_json_export/challenges.py
@@ -1,10 +1,11 @@
 from librelingo_types.data_types import Course
+
 from .challenge_types import (
-    get_options_challenge,
-    get_listening_challenge,
-    get_chips_challenge,
-    get_reverse_chips_challenge,
     get_cards_challenge,
+    get_chips_challenge,
+    get_listening_challenge,
+    get_options_challenge,
+    get_reverse_chips_challenge,
     get_short_input_challenge,
 )
 

--- a/apps/librelingo_json_export/librelingo_json_export/cli.py
+++ b/apps/librelingo_json_export/librelingo_json_export/cli.py
@@ -1,7 +1,9 @@
-from pathlib import Path
 import collections
+from pathlib import Path
+
 import click  # type: ignore
 from librelingo_yaml_loader import load_course
+
 from librelingo_json_export.export import export_course
 
 Settings = collections.namedtuple(

--- a/apps/librelingo_json_export/librelingo_json_export/course.py
+++ b/apps/librelingo_json_export/librelingo_json_export/course.py
@@ -1,4 +1,5 @@
 from librelingo_types.data_types import Course
+
 from .module import _get_module_summary
 
 

--- a/apps/librelingo_json_export/librelingo_json_export/dictionary.py
+++ b/apps/librelingo_json_export/librelingo_json_export/dictionary.py
@@ -17,8 +17,8 @@
     the output JSON files.
 """
 
-from librelingo_utils import clean_word, get_words_from_phrase
 from librelingo_types.data_types import Course, Word
+from librelingo_utils import clean_word, get_words_from_phrase
 
 
 def _get_raw_dictionary_item(course: Course, word: Word, is_in_target_language):

--- a/apps/librelingo_json_export/librelingo_json_export/export.py
+++ b/apps/librelingo_json_export/librelingo_json_export/export.py
@@ -1,10 +1,12 @@
-import logging
 import json
+import logging
 from pathlib import Path
+
 from librelingo_types.data_types import Course, Skill
 from slugify import slugify
-from .skills import _get_skill_data
+
 from .course import _get_course_data
+from .skills import _get_skill_data
 
 logger = logging.getLogger("librelingo_json_export")
 

--- a/apps/librelingo_json_export/librelingo_json_export/module.py
+++ b/apps/librelingo_json_export/librelingo_json_export/module.py
@@ -1,5 +1,5 @@
+from librelingo_utils import calculate_number_of_levels, get_opaque_id
 from slugify import slugify
-from librelingo_utils import get_opaque_id, calculate_number_of_levels
 
 
 def _get_module_summary(module):

--- a/apps/librelingo_json_export/librelingo_json_export/skills.py
+++ b/apps/librelingo_json_export/librelingo_json_export/skills.py
@@ -1,5 +1,6 @@
-from librelingo_utils import get_opaque_id, calculate_number_of_levels
 from librelingo_types.data_types import Course, Skill
+from librelingo_utils import calculate_number_of_levels, get_opaque_id
+
 from .challenges import _get_challenges_data
 
 

--- a/apps/librelingo_json_export/tests/test_challenges_clean_word.py
+++ b/apps/librelingo_json_export/tests/test_challenges_clean_word.py
@@ -1,6 +1,6 @@
 import collections
-import pytest
 
+import pytest
 from librelingo_utils import clean_word
 
 Example = collections.namedtuple("Example", ["input_str", "expected", "name"])

--- a/apps/librelingo_json_export/tests/test_challenges_define_word.py
+++ b/apps/librelingo_json_export/tests/test_challenges_define_word.py
@@ -1,9 +1,9 @@
 import re
-import pytest
 
+import pytest
 from librelingo_fakes import fakes
-from librelingo_types import DictionaryItem
 from librelingo_json_export.dictionary import _define_word
+from librelingo_types import DictionaryItem
 
 
 def test_definition_not_found():

--- a/apps/librelingo_json_export/tests/test_challenges_get_cards_challenge.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_cards_challenge.py
@@ -1,8 +1,8 @@
 import collections
-import pytest
 
-from librelingo_json_export.challenge_types import get_cards_challenge
+import pytest
 from librelingo_fakes import fakes
+from librelingo_json_export.challenge_types import get_cards_challenge
 
 Example = collections.namedtuple(
     "Example", ["word", "course", "expected_result", "name"]

--- a/apps/librelingo_json_export/tests/test_challenges_get_challenges_data.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_challenges_data.py
@@ -1,7 +1,6 @@
 import pytest
-
-from librelingo_json_export.challenges import _get_challenges_data
 from librelingo_fakes import fakes
+from librelingo_json_export.challenges import _get_challenges_data
 
 
 @pytest.fixture

--- a/apps/librelingo_json_export/tests/test_challenges_get_chips_challenge.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_chips_challenge.py
@@ -1,8 +1,8 @@
 import collections
-import pytest
 
-from librelingo_json_export.challenge_types import get_chips_challenge
+import pytest
 from librelingo_fakes import fakes
+from librelingo_json_export.challenge_types import get_chips_challenge
 
 Example = collections.namedtuple(
     "Example", ["phrase", "course", "expected_result", "name"]

--- a/apps/librelingo_json_export/tests/test_challenges_get_chips_from_phrase.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_chips_from_phrase.py
@@ -1,8 +1,8 @@
 import collections
-import pytest
 
-from librelingo_json_export.challenge_types import get_chips_from_phrase
+import pytest
 from librelingo_fakes import fakes
+from librelingo_json_export.challenge_types import get_chips_from_phrase
 
 
 def test_empty_string():

--- a/apps/librelingo_json_export/tests/test_challenges_get_options_challenge.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_options_challenge.py
@@ -1,8 +1,8 @@
 import collections
-import pytest
 
-from librelingo_json_export.challenge_types import get_options_challenge
+import pytest
 from librelingo_fakes import fakes
+from librelingo_json_export.challenge_types import get_options_challenge
 
 Example = collections.namedtuple(
     "Example", ["word", "course", "expected_result", "name"]

--- a/apps/librelingo_json_export/tests/test_challenges_get_phrase_challenges.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_phrase_challenges.py
@@ -1,7 +1,6 @@
 import pytest
-
-from librelingo_json_export.challenges import _get_phrase_challenges
 from librelingo_fakes import fakes
+from librelingo_json_export.challenges import _get_phrase_challenges
 
 challenges = _get_phrase_challenges(fakes.phrase1, fakes.course1)
 PHRASES_GROUPS = [challenge["group"] for challenge in challenges]

--- a/apps/librelingo_json_export/tests/test_challenges_get_short_input_challenge.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_short_input_challenge.py
@@ -1,8 +1,8 @@
 import collections
-import pytest
 
-from librelingo_json_export.challenge_types import get_short_input_challenge
+import pytest
 from librelingo_fakes import fakes
+from librelingo_json_export.challenge_types import get_short_input_challenge
 
 Example = collections.namedtuple(
     "Example", ["word", "course", "expected_result", "name"]

--- a/apps/librelingo_json_export/tests/test_challenges_get_word_challenges.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_word_challenges.py
@@ -1,8 +1,6 @@
 import pytest
-
-from librelingo_json_export.challenges import _get_word_challenges
 from librelingo_fakes import fakes
-
+from librelingo_json_export.challenges import _get_word_challenges
 
 challenges = _get_word_challenges(fakes.word1, fakes.course1)
 WORD_GROUPS = [challenge["group"] for challenge in challenges]

--- a/apps/librelingo_json_export/tests/test_challenges_listening_challenge.py
+++ b/apps/librelingo_json_export/tests/test_challenges_listening_challenge.py
@@ -1,10 +1,9 @@
 import collections
+
 import pytest
-
-from librelingo_json_export.challenge_types import get_listening_challenge
-from librelingo_types import Settings, AudioSettings
-
 from librelingo_fakes import fakes
+from librelingo_json_export.challenge_types import get_listening_challenge
+from librelingo_types import AudioSettings, Settings
 
 Example = collections.namedtuple(
     "Example", ["word", "course", "expected_result", "name"]

--- a/apps/librelingo_json_export/tests/test_cli.py
+++ b/apps/librelingo_json_export/tests/test_cli.py
@@ -1,9 +1,9 @@
 import os
-import pytest
 
+import pytest
 from click.testing import CliRunner  # type: ignore
-from librelingo_json_export.cli import main, DEFAULT_SETTINGS
 from librelingo_fakes import fakes
+from librelingo_json_export.cli import DEFAULT_SETTINGS, main
 
 
 @pytest.fixture

--- a/apps/librelingo_json_export/tests/test_course_get_course_data.py
+++ b/apps/librelingo_json_export/tests/test_course_get_course_data.py
@@ -1,6 +1,6 @@
 from librelingo_fakes import fakes
-from librelingo_utils import calculate_number_of_levels
 from librelingo_json_export.course import _get_course_data
+from librelingo_utils import calculate_number_of_levels
 
 course_with_markdown = fakes.customize(
     fakes.course2,

--- a/apps/librelingo_json_export/tests/test_export_course.py
+++ b/apps/librelingo_json_export/tests/test_export_course.py
@@ -1,7 +1,6 @@
 import pytest
-
-from librelingo_json_export.export import export_course
 from librelingo_fakes import fakes
+from librelingo_json_export.export import export_course
 
 
 @pytest.fixture

--- a/apps/librelingo_json_export/tests/test_export_course_data.py
+++ b/apps/librelingo_json_export/tests/test_export_course_data.py
@@ -1,11 +1,11 @@
-import os
 import json
 import logging
-import pytest
+import os
 
+import pytest
+from librelingo_fakes import fakes
 from librelingo_json_export.export import _export_course_data
 from librelingo_types import Language
-from librelingo_fakes import fakes
 
 
 @pytest.fixture

--- a/apps/librelingo_json_export/tests/test_export_course_skills.py
+++ b/apps/librelingo_json_export/tests/test_export_course_skills.py
@@ -1,8 +1,7 @@
 import pytest
-
+from librelingo_fakes import fakes
 from librelingo_json_export.export import _export_course_skills
 from librelingo_types import Module
-from librelingo_fakes import fakes
 
 
 @pytest.fixture

--- a/apps/librelingo_json_export/tests/test_export_skill.py
+++ b/apps/librelingo_json_export/tests/test_export_skill.py
@@ -1,11 +1,10 @@
-import os
 import json
 import logging
+import os
+
 import pytest
-
-from librelingo_json_export.export import _export_skill
-
 from librelingo_fakes import fakes
+from librelingo_json_export.export import _export_skill
 
 
 @pytest.fixture

--- a/apps/librelingo_json_export/tests/test_integration.py
+++ b/apps/librelingo_json_export/tests/test_integration.py
@@ -1,8 +1,9 @@
-import os
-import json
 import glob
-from librelingo_yaml_loader import load_course
+import json
+import os
+
 from librelingo_json_export.export import export_course
+from librelingo_yaml_loader import load_course
 
 
 def read_json_file(path):

--- a/apps/librelingo_json_export/tests/test_skills_get_skill_data.py
+++ b/apps/librelingo_json_export/tests/test_skills_get_skill_data.py
@@ -1,6 +1,5 @@
 import pytest
 from librelingo_fakes import fakes
-
 from librelingo_json_export.skills import _get_skill_data
 
 

--- a/apps/librelingo_utils/librelingo_utils/utils.py
+++ b/apps/librelingo_utils/librelingo_utils/utils.py
@@ -1,5 +1,6 @@
-from functools import lru_cache
 import hashlib
+from functools import lru_cache
+
 import regex  # type: ignore
 from librelingo_types.data_types import Course, Language, Phrase, Word
 

--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
@@ -1,29 +1,28 @@
 import collections
-from pathlib import Path
 import os
+from pathlib import Path
 from typing import List, Union
 
 import bleach
+import html2markdown  # type: ignore
+import markdown
 from librelingo_types import (
+    AudioSettings,
     Course,
     DictionaryItem,
     Language,
     License,
     Module,
     Phrase,
-    Skill,
-    Word,
     Settings,
-    AudioSettings,
+    Skill,
     TextToSpeechSettings,
+    Word,
 )
-import markdown
 from yaml import safe_load
 from yaml.constructor import SafeConstructor
 
-import html2markdown  # type: ignore
-
-from ._spelling import _run_skill_spellcheck, _convert_hunspell_settings
+from ._spelling import _convert_hunspell_settings, _run_skill_spellcheck
 
 
 def add_bool(self, node):

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
@@ -2,29 +2,30 @@ import os
 import re
 from pathlib import Path
 from unittest.mock import Mock, patch
+
 import pytest
-from pyfakefs.fake_filesystem_unittest import TestCase as FakeFsTestCase  # type: ignore
-from librelingo_types.data_types import Settings
+from librelingo_fakes import fakes
 from librelingo_types import (
     Course,
+    DictionaryItem,
+    HunspellSettings,
+    Language,
     License,
     Module,
-    Skill,
-    Word,
     Phrase,
-    Language,
-    DictionaryItem,
+    Skill,
     TextToSpeechSettings,
-    HunspellSettings,
+    Word,
 )
+from librelingo_types.data_types import Settings
 from librelingo_yaml_loader.yaml_loader import (
-    load_course,
     _convert_license,
     _load_module,
-    _load_skills,
     _load_skill,
+    _load_skills,
+    load_course,
 )
-from librelingo_fakes import fakes
+from pyfakefs.fake_filesystem_unittest import TestCase as FakeFsTestCase  # type: ignore
 
 
 class YamlImportTestCase(FakeFsTestCase):

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_convert_phrase.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_convert_phrase.py
@@ -3,11 +3,9 @@ this file contains tests of the funcion
 librelingo_yaml_loader.yaml_loader._convert_phrase
 """
 import pytest
-
+from librelingo_fakes import fakes
 from librelingo_types import Phrase
 from librelingo_yaml_loader.yaml_loader import _convert_phrase
-
-from librelingo_fakes import fakes
 
 
 def _access_functions(in_key):

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_convert_phrases.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_convert_phrases.py
@@ -3,10 +3,8 @@ this file contains tests of the funcion
 librelingo_yaml_loader.yaml_loader._convert_phrases
 """
 import pytest
-
-from librelingo_yaml_loader.yaml_loader import _convert_phrases
-
 from librelingo_fakes import fakes
+from librelingo_yaml_loader.yaml_loader import _convert_phrases
 
 
 def test_returns_a_list():

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_convert_word.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_convert_word.py
@@ -3,11 +3,9 @@ this file contains tests of the funcion
 librelingo_yaml_loader.yaml_loader._convert_word
 """
 import pytest
-
+from librelingo_fakes import fakes
 from librelingo_types import Word
 from librelingo_yaml_loader.yaml_loader import _convert_word
-
-from librelingo_fakes import fakes
 
 
 def _access_functions(in_key):

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_convert_words.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_convert_words.py
@@ -3,10 +3,8 @@ this file contains tests of the funcion
 librelingo_yaml_loader.yaml_loader._convert_words
 """
 import pytest
-
-from librelingo_yaml_loader.yaml_loader import _convert_words
-
 from librelingo_fakes import fakes
+from librelingo_yaml_loader.yaml_loader import _convert_words
 
 
 def test_returns_a_list():

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_dictionary.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_dictionary.py
@@ -1,14 +1,6 @@
 import pytest
-
-from librelingo_types import (
-    Module,
-    Skill,
-    Word,
-    DictionaryItem,
-)
-from librelingo_yaml_loader.yaml_loader import (
-    _load_dictionary,
-)
+from librelingo_types import DictionaryItem, Module, Skill, Word
+from librelingo_yaml_loader.yaml_loader import _load_dictionary
 
 from .utils import get_fake_word
 

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_modules.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_modules.py
@@ -3,10 +3,10 @@ this file contains tests of the funcion
 librelingo_yaml_loader.yaml_loader._load_modules
 """
 from pathlib import Path
-import pytest
 
-from librelingo_yaml_loader.yaml_loader import _load_modules
+import pytest
 from librelingo_fakes import fakes
+from librelingo_yaml_loader.yaml_loader import _load_modules
 
 
 @pytest.fixture

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py
@@ -3,10 +3,10 @@ this file contains tests of the funcion
 librelingo_yaml_loader.yaml_loader._load_skills
 """
 from pathlib import Path
-import pytest
 
-from librelingo_yaml_loader.yaml_loader import _load_skills
+import pytest
 from librelingo_fakes import fakes
+from librelingo_yaml_loader.yaml_loader import _load_skills
 
 
 @pytest.fixture

--- a/apps/tools/librelingo_tools/generate.py
+++ b/apps/tools/librelingo_tools/generate.py
@@ -4,9 +4,10 @@ import datetime
 import json
 import logging
 import os
-import zipfile
 import shutil
 import tempfile
+import zipfile
+
 import requests
 from jinja2 import Environment, FileSystemLoader
 

--- a/apps/tools/librelingo_tools/lili-search.py
+++ b/apps/tools/librelingo_tools/lili-search.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-import sys
 import re
+import sys
+
 from librelingo_yaml_loader.yaml_loader import load_course
 
 reports = {}

--- a/apps/tools/librelingo_tools/lili.py
+++ b/apps/tools/librelingo_tools/lili.py
@@ -6,11 +6,11 @@ import logging
 import os
 import re
 import sys
+
 import markdown
 from jinja2 import Environment, FileSystemLoader
-
-from librelingo_yaml_loader.yaml_loader import load_course
 from librelingo_json_export.export import export_course
+from librelingo_yaml_loader.yaml_loader import load_course
 
 Settings = collections.namedtuple(
     "Settings",

--- a/apps/tools/librelingo_tools/translate.py
+++ b/apps/tools/librelingo_tools/translate.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 # import os
-import sys
 import re
+import sys
 
 # from collections import defaultdict
 # from librelingo_yaml_loader.yaml_loader import load_course

--- a/apps/tools/practice.py
+++ b/apps/tools/practice.py
@@ -2,13 +2,10 @@
 import argparse
 import random
 
-from librelingo_tools.lili import (  # type: ignore
-    guess_path_to_course,
-    collect_data,
-    collect_words,
-    collect_phrases,
-)
 from librelingo_yaml_loader.yaml_loader import load_course
+
+from librelingo_tools.lili import collect_data  # type: ignore
+from librelingo_tools.lili import collect_phrases, collect_words, guess_path_to_course
 
 
 def get_args():


### PR DESCRIPTION
- reorganize imports according to pep8 suggestions to have the following organization:
  - Standard library imports.
  - Related third party imports.
  - Local application/library specific imports. 

And also to order them alphabetically