### PR TITLE
add makefile with a few commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ backend-ci: ## Run python corresponding ci
 	make format && make lint && make type-check
 
 help:
-	grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+PYTHON_FILEPATHS = `(find . -iname "*.py" -not -path "./.venv/*")`
+lint: ## Lint codebase
+	poetry run pylint --rcfile=pylintrc $(PYTHON_FILEPATHS)
+
+format: ## Run black formatter
+	poetry run black --check $(PYTHON_FILEPATHS)
+
+format-fix: ## Run black formatter with automated fix
+	poetry run black $(PYTHON_FILEPATHS)
+
+type-check: ## Run black formatter with automated fix
+	poetry run mypy $(PYTHON_FILEPATHS)
+
+pycache-delete: ## Delete the __pycache__ folders
+	find . -type d -name __pycache__ -exec rm -r {} \+
+
+clean: ## Delete cache generated
+	rm -fr .mypy_cache/ .pytest_cache/ && make pycache-delete
+
+backend-ci: ## Run python corresponding ci
+	make format && make lint && make type-check
+
+help:
+	grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This PR is here to open a few discussions concerning some points i was thinking of (yes i just had some extra time haha)

But can we get rid of those `git ls-files '*.py'` from the CI and use some `$(find...)` command, it will not make a big change, but for the next contributors i feel like they will be using this command to simulate the CI whenever it fails, which can lead to some errors on their side (just dev UX), as this command will fail whenever a file is added or removed and is not commited.

A second point, is to have a makefile with useful commands, also a help command that will generate the documentation of those commands, with the pushed makefile we have something similar to:

<img width="535" alt="Screenshot 2022-02-20 at 11 40 39" src="https://user-images.githubusercontent.com/66479002/154838687-4f18e444-5aab-4ce1-b36c-6c6435f8101a.png">
 
that is pretty useful for users not used for the codebase (and it's useful just to find quickly the needed commands)

I also added cache deletion commands if anyone need them :) ! 

Eager to have your returns on each and if anyone is reluctant :)