### PR TITLE
feat: allow the creation of two-way dictionaries 

### DIFF
--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
@@ -220,6 +220,23 @@ def _convert_phrases(raw_phrases) -> List[Phrase]:
     return list(map(_convert_phrase, raw_phrases))
 
 
+def _convert_two_way_dictionary(data, course: Course):
+    """
+    Handles loading the twoway-dictionary form the YAML format
+    """
+    dictionary = []
+    # return dictionary
+    if "Twoway-dictionary" not in data:
+        return dictionary
+    raw_two_way_dictionary = data["Twoway-dictionary"]
+    for item in raw_two_way_dictionary:
+        word = list(item.keys())[0]
+        translation = item[word]
+        dictionary.append((word, ([translation]), False))
+        dictionary.append((translation, ([word]), True))
+    return dictionary
+
+
 def _convert_mini_dictionary(data, course: Course):
     """
     Handles loading the mini-dictionary form the YAML format
@@ -310,7 +327,8 @@ def _load_skill(path: Path, course: Course) -> Skill:
         words=words,
         phrases=phrases,
         image_set=skill["Thumbnails"] if "Thumbnails" in skill else [],
-        dictionary=list(_convert_mini_dictionary(data, course)),
+        dictionary=list(_convert_mini_dictionary(data, course))
+        + _convert_two_way_dictionary(data, course),
         introduction=introduction,
     )
 

--- a/apps/librelingo_yaml_loader/tests/fixtures/fake_course/basics/skills/hello.yaml
+++ b/apps/librelingo_yaml_loader/tests/fixtures/fake_course/basics/skills/hello.yaml
@@ -62,3 +62,10 @@ Mini-dictionary:
     - source_word: target_translation_1
     - source_word: target_translation_2
     - source_word: target_translation_2
+
+Twoway-dictionary:
+  - source_1: target_1
+  - source_2: target_2_a
+  - source_2: target_2_b
+  - source_3_a: target_3
+  - source_3_b: target_3

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
@@ -373,6 +373,34 @@ def test_load_course_output_matches_value(fs):
                 definition="target_translation_1\ntarget_translation_2",
                 is_in_target_language=False,
             ),
+            DictionaryItem(
+                word="source_1", definition="target_1", is_in_target_language=False
+            ),
+            DictionaryItem(
+                word="target_1", definition="source_1", is_in_target_language=True
+            ),
+            DictionaryItem(
+                word="source_2",
+                definition="target_2_a\ntarget_2_b",
+                is_in_target_language=False,
+            ),
+            DictionaryItem(
+                word="target_2_a", definition="source_2", is_in_target_language=True
+            ),
+            DictionaryItem(
+                word="target_2_b", definition="source_2", is_in_target_language=True
+            ),
+            DictionaryItem(
+                word="source_3_a", definition="target_3", is_in_target_language=False
+            ),
+            DictionaryItem(
+                word="source_3_b", definition="target_3", is_in_target_language=False
+            ),
+            DictionaryItem(
+                word="target_3",
+                definition="source_3_a\nsource_3_b",
+                is_in_target_language=True,
+            ),
         ]
     )
     assert len(result.modules) == 1


### PR DESCRIPTION
Instead of adding a pair of words in both direction of the mini-dictionary, this will allow adding the pair only once and it will add the entry in both directions.