### PR TITLE
Enable pylint duplicate-code rule

### DIFF
--- a/apps/librelingo_audios/librelingo_audios/update_audios.py
+++ b/apps/librelingo_audios/librelingo_audios/update_audios.py
@@ -118,10 +118,11 @@ def _generate_audio_with_tts(
         )
         # This is where more more TTS providers would be added with an if statement.
         # For now there is only Polly.
+        tts_provider = "polly"
         subprocess.run(
             [
                 "aws",
-                "polly",
+                tts_provider,
                 "synthesize-speech",
                 "--output-format",
                 "mp3",

--- a/apps/librelingo_fakes/librelingo_fakes/fakes.py
+++ b/apps/librelingo_fakes/librelingo_fakes/fakes.py
@@ -302,3 +302,8 @@ def get_fake_skill(introduction=None):
         name=f"Animals {random_word}",
         introduction=introduction,
     )
+
+
+def settings_not_dry_run():
+    SettingsDryRun = namedtuple("Settings", ["dry_run"])
+    return SettingsDryRun(False)

--- a/apps/tools/tests/test_real_courses.py
+++ b/apps/tools/tests/test_real_courses.py
@@ -1,5 +1,4 @@
 # pylint: skip-file
-import collections
 import os
 import pytest
 
@@ -19,13 +18,7 @@ from librelingo_types import (
     #    TextToSpeechSettings,
     #    Word,
 )
-
-Settings = collections.namedtuple(
-    "Settings",
-    [
-        "dry_run",
-    ],
-)
+from librelingo_fakes import fakes
 
 
 def load(name):
@@ -39,9 +32,7 @@ def load(name):
 
 def test_error_1(tmpdir):
     course = load("e1")
-    settings = Settings(
-        dry_run=False,
-    )
+    settings = fakes.settings_not_dry_run()
 
     with pytest.raises(RuntimeError) as err:
         export_course(str(tmpdir), course, settings)
@@ -54,9 +45,7 @@ def test_error_1(tmpdir):
 
 def test_error_2(tmpdir):
     course = load("e2")
-    settings = Settings(
-        dry_run=False,
-    )
+    settings = fakes.settings_not_dry_run()
 
     # issue: https://github.com/LibreLingo/LibreLingo/issues/1885
     with pytest.raises(RuntimeError) as err:
@@ -104,9 +93,7 @@ def test_minimal(tmpdir):
         )
     ]
 
-    settings = Settings(
-        dry_run=False,
-    )
+    settings = fakes.settings_not_dry_run()
 
     # We make sure there is no exception.
     # Maybe we should also compare the results to some expected files?

--- a/apps/tools/tests/test_test_course.py
+++ b/apps/tools/tests/test_test_course.py
@@ -1,17 +1,10 @@
 # pylint: skip-file
-import collections
 import json
 import os
 
 from librelingo_json_export.export import export_course
 from librelingo_yaml_loader.yaml_loader import load_course
-
-Settings = collections.namedtuple(
-    "Settings",
-    [
-        "dry_run",
-    ],
-)
+from librelingo_fakes import fakes
 
 
 def test_exported_test_course_matches_snapshot(tmpdir):
@@ -20,13 +13,10 @@ def test_exported_test_course_matches_snapshot(tmpdir):
     root = os.path.dirname(root)
     root = os.path.dirname(root)
     root = os.path.dirname(root)
-
     path_to_course = os.path.join(root, "courses", "test")
     course = load_course(path_to_course)
 
-    settings = Settings(
-        dry_run=False,
-    )
+    settings = fakes.settings_not_dry_run()
     output_path = str(tmpdir)
     expected_path = os.path.join(root, "apps", "web", "src", "courses", "test")
 

--- a/pylintrc
+++ b/pylintrc
@@ -84,7 +84,6 @@ disable=raw-checker-failed,
         file-ignored,
         suppressed-message,
         useless-suppression,
-        duplicate-code,  # TODO: enable
         invalid-name,  # TODO: enable
         missing-function-docstring,  # TODO: enable
         redefined-outer-name,  # TODO: enable

--- a/pylintrc
+++ b/pylintrc
@@ -447,10 +447,10 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Imports are removed from the similarity computation
-ignore-imports=no
+ignore-imports=yes
 
 # Signatures are removed from the similarity computation
-ignore-signatures=no
+ignore-signatures=yes
 
 # Minimum lines number of a similarity.
 min-similarity-lines=4


### PR DESCRIPTION
## Description

Enabled the "duplicate-code" rule in the pylint config and changed the configuration settings for the rule. Refactored the following files to reduce the amount of duplicate code:

_apps/tools/tests/test_real_courses.py
apps/tools/tests/test_test_course.py_
Import the Settings object from fakes instead of declaring a new one

_apps/librelingo_audios/librelingo_audios/update_audios.py_
Pylint found lines 122-127 to be too similar to lines 73-78 of _conftest.py_. This seems to me to be an acceptable case of duplicate code, given that the lines of _conftest.py_ are used to test those from _update_audios.py_. However, the CI will not pass if they are left as is, so it was necessary to make some change. It seemed sensible to use a variable for TTS provider, given that more providers could be added in future.

**Is this related to any open issue(s)?**

fixes #1924

**Is there anything you need help with to get this PR merged?**

...
## Checklist

Don't worry if you haven't done everything on this checklist. Simply create your PR, and make sure everything is done later,
or ask for help if you don't know how to do it.

- [ ] The CI is passing
- [x] I tested my implementation manually
- [ ] I wrote new tests to test my code, or updated existing tests to test my changes