### PR TITLE
chore(pylint): enable invalid-name

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -85,7 +85,6 @@ disable=raw-checker-failed,
         suppressed-message,
         useless-suppression,
         duplicate-code,  # TODO: enable
-        invalid-name,  # TODO: enable
         missing-function-docstring,  # TODO: enable
         redefined-outer-name,  # TODO: enable
         missing-class-docstring,  # TODO: enable
@@ -108,7 +107,7 @@ disable=raw-checker-failed,
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
 # enable=c-extension-no-member
-
+enable = invalid-name, 
 
 [REPORTS]
 


### PR DESCRIPTION
**### Description**
Enabled the "invalid-name" attribute within the _pylintrc_ file and removed it from the disabled list.
![image](https://user-images.githubusercontent.com/38736785/193475442-2c6092be-4aca-4cd1-8a79-31ce8a39a93b.png)

NOTE: "invalid-name" was not located in any other file and did have any imports, second commit was not needed.