### PR TITLE
Fix virtual keyboard being cut in half for audio task

### DIFF
--- a/apps/lluis/HorizontalScroller.svelte
+++ b/apps/lluis/HorizontalScroller.svelte
@@ -46,9 +46,7 @@
   }
 
   .content {
-    position: absolute;
-    top: 0;
-    left: 0;
+    position: relative;
     width: 100%;
     height: 100%;
     overflow-x: auto;


### PR DESCRIPTION
After a certain number of characters, the virtual keyboard would cut off on the second row.
This appears (thus far) to only occur for the French course, as there are not enough characters in the others.

This pull request adjusts the `position` property of the keyboard from `absolute` to `relative`.
This allows the entire keyboard to be seen instead of only partly seen.
This is my first pull request, so let me know if there's anything I can do better!

Resolves #2442