### PR TITLE
chore: add macos-11

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9"]
-        os: [ubuntu-18.04]
+        os: [ubuntu-18.04, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -15,14 +15,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
+        uses: snok/install-poetry@v1
       - name: Install Python Dependencies
+        shell: bash
         run: poetry install
       - name: Test Python packages
+        shell: bash
         run: poetry run pytest --doctest-modules
       - name: Test Python types (mypy)
+        shell: bash
         run: poetry run mypy apps
       - name: Python code style (black)
+        shell: bash
         run: poetry run black apps --check
       - name: Python code style (pylint)
+        shell: bash
         run: poetry run pylint $(git ls-files '*.py')


### PR DESCRIPTION
I added `macos-11` to [python workflow](https://github.com/LibreLingo/LibreLingo/blob/a012439e84ba3ca2661ed4954fb33df79396da2f/.github/workflows/python.yml).

`poetry` is installed using [`snok/install-poetry@v1`](https://github.com/snok/install-poetry) - this will also work on windows. Installing `poetry` in this way, requires `bash` as a shell in every relevant step. I am open here for other suggestions.

This should solve #2479.

@ztjhz please have a look - it might be relevant to #2480.