### PR TITLE
Python ci windows check

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9"]
-        os: [ubuntu-18.04]
+        os: [ubuntu-18.04, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,6 +8,9 @@ jobs:
       matrix:
         python-version: ["3.9"]
         os: [ubuntu-18.04, windows-latest]
+    defaults:
+      run:
+        shell: bash
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -15,7 +18,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
+        uses: snok/install-poetry@v1
       - name: Install Python Dependencies
         run: poetry install
       - name: Test Python packages

--- a/apps/librelingo_json_export/tests/snapshots/snap_test_integration.py
+++ b/apps/librelingo_json_export/tests/snapshots/snap_test_integration.py
@@ -215,7 +215,9 @@ le""",
         "id": "379dca1c8ae9",
         "levels": 2,
     },
-    str(Path("./output/introduction/hello.md")): """# Lorem Ipsum
+    str(
+        Path("./output/introduction/hello.md")
+    ): """# Lorem Ipsum
 
 ## Dolor sit amet
 

--- a/apps/librelingo_json_export/tests/snapshots/snap_test_integration.py
+++ b/apps/librelingo_json_export/tests/snapshots/snap_test_integration.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
 from __future__ import unicode_literals
+from pathlib import Path
 
 from snapshottest import Snapshot  # type: ignore
 
 snapshots = Snapshot()
 
 snapshots["test_loaded_yaml_is_exported_to_correct_json 1"] = {
-    "./output/challenges/hello.json": {
+    str(Path("./output/challenges/hello.json")): {
         "challenges": [
             {
                 "formInTargetLanguage": "La femme dit bonjour",
@@ -214,7 +215,7 @@ le""",
         "id": "379dca1c8ae9",
         "levels": 2,
     },
-    "./output/introduction/hello.md": """# Lorem Ipsum
+    str(Path("./output/introduction/hello.md")): """# Lorem Ipsum
 
 ## Dolor sit amet
 

--- a/apps/librelingo_json_export/tests/test_integration.py
+++ b/apps/librelingo_json_export/tests/test_integration.py
@@ -1,6 +1,7 @@
 import glob
 import json
 import os
+from pathlib import Path
 
 from librelingo_json_export.export import export_course
 from librelingo_yaml_loader import load_course
@@ -19,7 +20,7 @@ def test_loaded_yaml_is_exported_to_correct_json(fs, snapshot):
     export_course("./output", course)
     files = glob.glob("./output/**/*")
     data = {
-        fname: read_json_file(fname) if fname.endswith(".json") else open(fname).read()
+        str(Path(fname)): read_json_file(fname) if fname.endswith(".json") else open(fname).read()
         for fname in files
     }
 

--- a/apps/librelingo_json_export/tests/test_integration.py
+++ b/apps/librelingo_json_export/tests/test_integration.py
@@ -20,7 +20,9 @@ def test_loaded_yaml_is_exported_to_correct_json(fs, snapshot):
     export_course("./output", course)
     files = glob.glob("./output/**/*")
     data = {
-        str(Path(fname)): read_json_file(fname) if fname.endswith(".json") else open(fname).read()
+        str(Path(fname)): read_json_file(fname)
+        if fname.endswith(".json")
+        else open(fname).read()
         for fname in files
     }
 

--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
@@ -20,7 +20,11 @@ from librelingo_types import (
     TextToSpeechSettings,
     Word,
 )
-from yaml import load, CSafeLoader
+from yaml import load
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader  # type: ignore
 from yaml.constructor import SafeConstructor
 
 from ._spelling import _convert_hunspell_settings, _run_skill_spellcheck
@@ -35,8 +39,8 @@ SafeConstructor.add_constructor("tag:yaml.org,2002:bool", add_bool)
 
 def _load_yaml(path: Path):
     """Helper function for reading a YAML file"""
-    with open(path) as yaml_file:
-        return load(yaml_file, Loader=CSafeLoader)
+    with open(path, encoding="utf-8") as yaml_file:
+        return load(yaml_file, Loader=SafeLoader)
 
 
 def _convert_language(raw_language) -> Language:

--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
@@ -21,6 +21,7 @@ from librelingo_types import (
     Word,
 )
 from yaml import load
+
 try:
     from yaml import CSafeLoader as SafeLoader
 except ImportError:

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
@@ -705,9 +705,7 @@ Mini-dictionary:
 def test_load_module_complains_about_an_empty_file(load_yaml):
     random_path = fakes.path()
     load_yaml.return_value = None
-    expected_error = (
-        f'Module file "{str(Path(random_path)/"module.yaml")}" is empty or does not exist'
-    )
+    expected_error = f'Module file "{str(Path(random_path)/"module.yaml")}" is empty or does not exist'
     with pytest.raises(
         RuntimeError,
         match=re.escape(expected_error),
@@ -719,9 +717,7 @@ def test_load_module_complains_about_an_empty_file(load_yaml):
 def test_load_module_complains_missing_module_key(load_yaml):
     random_path = fakes.path()
     load_yaml.return_value = {}
-    expected_error = (
-        f'Module file "{str(Path(random_path)/"module.yaml")}" needs to have a "Module" key'
-    )
+    expected_error = f'Module file "{str(Path(random_path)/"module.yaml")}" needs to have a "Module" key'
     with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         _load_module(random_path, fakes.course1)
 
@@ -730,9 +726,7 @@ def test_load_module_complains_missing_module_key(load_yaml):
 def test_load_module_complains_missing_skills_key(load_yaml):
     random_path = fakes.path()
     load_yaml.return_value = {"Module": {}}
-    expected_error = (
-        f'Module file "{str(Path(random_path)/"module.yaml")}" needs to have a "Skills" key'
-    )
+    expected_error = f'Module file "{str(Path(random_path)/"module.yaml")}" needs to have a "Skills" key'
     with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         _load_module(random_path, fakes.course1)
 
@@ -741,9 +735,7 @@ def test_load_module_complains_missing_skills_key(load_yaml):
 def test_load_module_complains_missing_module_name(load_yaml):
     random_path = fakes.path()
     load_yaml.return_value = {"Module": {}, "Skills": []}
-    expected_error = (
-        f'Module file "{str(Path(random_path)/"module.yaml")}" needs to have module name'
-    )
+    expected_error = f'Module file "{str(Path(random_path)/"module.yaml")}" needs to have module name'
     with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         _load_module(random_path, fakes.course1)
 

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
@@ -705,7 +705,8 @@ Mini-dictionary:
 def test_load_module_complains_about_an_empty_file(load_yaml):
     random_path = fakes.path()
     load_yaml.return_value = None
-    expected_error = f'Module file "{str(Path(random_path)/"module.yaml")}" is empty or does not exist'
+    file_path = str(Path(random_path) / "module.yaml")
+    expected_error = f'Module file "{file_path}" is empty or does not exist'
     with pytest.raises(
         RuntimeError,
         match=re.escape(expected_error),
@@ -717,7 +718,8 @@ def test_load_module_complains_about_an_empty_file(load_yaml):
 def test_load_module_complains_missing_module_key(load_yaml):
     random_path = fakes.path()
     load_yaml.return_value = {}
-    expected_error = f'Module file "{str(Path(random_path)/"module.yaml")}" needs to have a "Module" key'
+    file_path = str(Path(random_path) / "module.yaml")
+    expected_error = f'Module file "{file_path}" needs to have a "Module" key'
     with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         _load_module(random_path, fakes.course1)
 
@@ -726,7 +728,8 @@ def test_load_module_complains_missing_module_key(load_yaml):
 def test_load_module_complains_missing_skills_key(load_yaml):
     random_path = fakes.path()
     load_yaml.return_value = {"Module": {}}
-    expected_error = f'Module file "{str(Path(random_path)/"module.yaml")}" needs to have a "Skills" key'
+    file_path = str(Path(random_path) / "module.yaml")
+    expected_error = f'Module file "{file_path}" needs to have a "Skills" key'
     with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         _load_module(random_path, fakes.course1)
 
@@ -735,7 +738,8 @@ def test_load_module_complains_missing_skills_key(load_yaml):
 def test_load_module_complains_missing_module_name(load_yaml):
     random_path = fakes.path()
     load_yaml.return_value = {"Module": {}, "Skills": []}
-    expected_error = f'Module file "{str(Path(random_path)/"module.yaml")}" needs to have module name'
+    file_path = str(Path(random_path) / "module.yaml")
+    expected_error = f'Module file "{file_path}" needs to have module name'
     with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         _load_module(random_path, fakes.course1)
 

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
@@ -422,7 +422,7 @@ def test_load_course_output_matches_value(fs):
     assert len(result.modules[0].skills) == 1
     assert result.modules[0].skills[0] == Skill(
         name="Hello",
-        filename="basics/skills/hello.yaml",
+        filename=str(Path("basics/skills/hello.yaml")),
         id=4,
         image_set=["people1", "woman1", "man1"],
         phrases=result.modules[0].skills[0].phrases,
@@ -705,9 +705,12 @@ Mini-dictionary:
 def test_load_module_complains_about_an_empty_file(load_yaml):
     random_path = fakes.path()
     load_yaml.return_value = None
+    expected_error = (
+        f'Module file "{str(Path(random_path)/"module.yaml")}" is empty or does not exist'
+    )
     with pytest.raises(
         RuntimeError,
-        match=f'Module file "{random_path}/module.yaml" is empty or does not exist',
+        match=re.escape(expected_error),
     ):
         _load_module(random_path, fakes.course1)
 
@@ -717,9 +720,9 @@ def test_load_module_complains_missing_module_key(load_yaml):
     random_path = fakes.path()
     load_yaml.return_value = {}
     expected_error = (
-        f'Module file "{random_path}/module.yaml" needs to have a "Module" key'
+        f'Module file "{str(Path(random_path)/"module.yaml")}" needs to have a "Module" key'
     )
-    with pytest.raises(RuntimeError, match=expected_error):
+    with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         _load_module(random_path, fakes.course1)
 
 
@@ -728,9 +731,9 @@ def test_load_module_complains_missing_skills_key(load_yaml):
     random_path = fakes.path()
     load_yaml.return_value = {"Module": {}}
     expected_error = (
-        f'Module file "{random_path}/module.yaml" needs to have a "Skills" key'
+        f'Module file "{str(Path(random_path)/"module.yaml")}" needs to have a "Skills" key'
     )
-    with pytest.raises(RuntimeError, match=expected_error):
+    with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         _load_module(random_path, fakes.course1)
 
 
@@ -739,9 +742,9 @@ def test_load_module_complains_missing_module_name(load_yaml):
     random_path = fakes.path()
     load_yaml.return_value = {"Module": {}, "Skills": []}
     expected_error = (
-        f'Module file "{random_path}/module.yaml" needs to have module name'
+        f'Module file "{str(Path(random_path)/"module.yaml")}" needs to have module name'
     )
-    with pytest.raises(RuntimeError, match=expected_error):
+    with pytest.raises(RuntimeError, match=re.escape(expected_error)):
         _load_module(random_path, fakes.course1)
 
 

--- a/apps/tools/tests/test_real_courses.py
+++ b/apps/tools/tests/test_real_courses.py
@@ -2,6 +2,7 @@
 import collections
 import os
 import pytest
+from pathlib import Path
 
 from librelingo_json_export.export import export_course
 from librelingo_yaml_loader.yaml_loader import load_course
@@ -48,7 +49,7 @@ def test_error_1(tmpdir):
     assert (
         str(err.value)
         # pylint: disable=line-too-long
-        == """Error while exporting skill "Hello" in file "basics/skills/hello.yaml": The English word "Excuse me" does not have a definition. Please add it to the mini-dictionary."""
+        == f"""Error while exporting skill "Hello" in file "{str(Path("basics/skills/hello.yaml"))}": The English word "Excuse me" does not have a definition. Please add it to the mini-dictionary."""
     )
 
 
@@ -64,7 +65,7 @@ def test_error_2(tmpdir):
     assert (
         str(err.value)
         # pylint: disable=line-too-long
-        == """Error while exporting skill "Hello" in file "basics/skills/hello.yaml": The English word "uncompersick" does not have a definition. Please add it to the mini-dictionary."""
+        == f"""Error while exporting skill "Hello" in file "{str(Path("basics/skills/hello.yaml"))}": The English word "uncompersick" does not have a definition. Please add it to the mini-dictionary."""
     )
 
 
@@ -79,7 +80,7 @@ def test_minimal(tmpdir):
     )
     assert course.dictionary == []
     assert course.repository_url == "https://www.example.com/course"
-    assert course.course_dir.endswith("tools/tests/fixtures/minimal")
+    assert course.course_dir.endswith(str(Path("tools/tests/fixtures/minimal")))
     # assert course.settings == Settings(
     #    audio_settings=AudioSettings(enabled=False, text_to_speech_settings_list=[]),
     #    hunspell=HunspellSettings(source_language=None, target_language=None),
@@ -92,7 +93,7 @@ def test_minimal(tmpdir):
             skills=[
                 Skill(
                     name="Hello",
-                    filename="basics/skills/hello.yaml",
+                    filename=str(Path("basics/skills/hello.yaml")),
                     id=1,
                     words=[],
                     phrases=[],

--- a/apps/tools/tests/test_test_course.py
+++ b/apps/tools/tests/test_test_course.py
@@ -40,9 +40,9 @@ def assert_folders_are_identical(expected_path, actual_path):
             relpath = os.path.join(dirname[len(actual_path) + 1 :], filename)
 
             if filename.endswith(".json"):
-                with open(os.path.join(actual_path, relpath), encoding='utf-8') as fh:
+                with open(os.path.join(actual_path, relpath), encoding="utf-8") as fh:
                     actual = json.load(fh)
-                with open(os.path.join(expected_path, relpath), encoding='utf-8') as fh:
+                with open(os.path.join(expected_path, relpath), encoding="utf-8") as fh:
                     expected = json.load(fh)
                 assert actual == expected, relpath
                 continue

--- a/apps/tools/tests/test_test_course.py
+++ b/apps/tools/tests/test_test_course.py
@@ -40,9 +40,9 @@ def assert_folders_are_identical(expected_path, actual_path):
             relpath = os.path.join(dirname[len(actual_path) + 1 :], filename)
 
             if filename.endswith(".json"):
-                with open(os.path.join(actual_path, relpath)) as fh:
+                with open(os.path.join(actual_path, relpath), encoding='utf-8') as fh:
                     actual = json.load(fh)
-                with open(os.path.join(expected_path, relpath)) as fh:
+                with open(os.path.join(expected_path, relpath), encoding='utf-8') as fh:
                     expected = json.load(fh)
                 assert actual == expected, relpath
                 continue


### PR DESCRIPTION
# Closes #2480

This pull request adds windows to the CI of GitHub Actions, while fixing issues prevalent on windows machine.


## Issue 1: Poetry is not added to `PATH` on windows

Solution: set the default shell to `bash` in `python.yml`
```yaml
defaults:
  run:
    shell: bash
```

## Issue 2: File separator is different on linux (`/`) and windows (`\`). Hence, hard-coded file paths will fail on windows.

Solution: utilise dynamic file paths
Example: change `"./output/challenges/hello.json"` to `str(Path("./output/challenges/hello.json"))`

## Issue 3: Regex string not escaped
For the regex matching in `pytest.raises(RuntimeError, match=expected_error)`, the `expected_error` was not escaped. This might cause errors in certain scenarios like windows file separator being `\\` . Hence, we need to escape it first by using `re.escape()`

## Issue 4: Character encoding not specified

Not specifying character encoding when reading files, might result in different special characters being read on windows and unicode decode errors.

Solution: specify the encoding:
```python
with open(path, encoding="utf-8") as yaml_file:
```

Please review the changes @kantord :)