### PR TITLE
Ensure that YAML loader works without PyYAML C bindings

### DIFF
--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
@@ -1,3 +1,4 @@
+import logging
 import collections
 import os
 import re
@@ -26,6 +27,8 @@ from yaml.constructor import SafeConstructor
 
 from ._spelling import _convert_hunspell_settings, _run_skill_spellcheck
 
+logger = logging.getLogger("librelingo_yaml_loader")
+
 
 def add_bool(self, node):
     return self.construct_scalar(node)
@@ -42,7 +45,7 @@ def _load_yaml(path: Path):
 
             return load(yaml_file, Loader=CSafeLoader)
         except ImportError:
-            print(
+            logger.warning(
                 """Warning! PyYAML LibYAML C bindings are not installed.
              Course loading still works, but it will be slower.
              For more details, check https://github.com/yaml/pyyaml#Installation"""

--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
@@ -50,7 +50,7 @@ SafeConstructor.add_constructor("tag:yaml.org,2002:bool", add_bool)
 
 def _load_yaml(path: Path):
     """Helper function for reading a YAML file"""
-    with open(path) as yaml_file:
+    with open(path, encoding="utf-8") as yaml_file:
         return load(yaml_file, Loader=SafeLoader)
 
 
@@ -300,7 +300,7 @@ def _load_introduction(path: str) -> Union[str, None]:
     if not os.path.exists(path):
         return None
 
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return _sanitize_markdown(f.read())
 
 

--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
@@ -28,6 +28,17 @@ from yaml.constructor import SafeConstructor
 from ._spelling import _convert_hunspell_settings, _run_skill_spellcheck
 
 logger = logging.getLogger("librelingo_yaml_loader")
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    logger.warning(
+        """
+    Warning! PyYAML LibYAML C bindings are not installed.
+    Course loading still works, but it will be slower.
+    For more details, check https://github.com/yaml/pyyaml#Installation
+    """
+    )
+    from yaml import SafeLoader  # type: ignore
 
 
 def add_bool(self, node):
@@ -40,19 +51,7 @@ SafeConstructor.add_constructor("tag:yaml.org,2002:bool", add_bool)
 def _load_yaml(path: Path):
     """Helper function for reading a YAML file"""
     with open(path) as yaml_file:
-        try:
-            from yaml import CSafeLoader
-
-            return load(yaml_file, Loader=CSafeLoader)
-        except ImportError:
-            logger.warning(
-                """Warning! PyYAML LibYAML C bindings are not installed.
-             Course loading still works, but it will be slower.
-             For more details, check https://github.com/yaml/pyyaml#Installation"""
-            )
-            from yaml import SafeLoader
-
-            return load(yaml_file, Loader=SafeLoader)
+        return load(yaml_file, Loader=SafeLoader)
 
 
 def _convert_language(raw_language) -> Language:

--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
@@ -22,10 +22,6 @@ from librelingo_types import (
 )
 from yaml import load
 
-try:
-    from yaml import CSafeLoader as SafeLoader
-except ImportError:
-    from yaml import SafeLoader  # type: ignore
 from yaml.constructor import SafeConstructor
 
 from ._spelling import _convert_hunspell_settings, _run_skill_spellcheck
@@ -40,8 +36,20 @@ SafeConstructor.add_constructor("tag:yaml.org,2002:bool", add_bool)
 
 def _load_yaml(path: Path):
     """Helper function for reading a YAML file"""
-    with open(path, encoding="utf-8") as yaml_file:
-        return load(yaml_file, Loader=SafeLoader)
+    with open(path) as yaml_file:
+        try:
+            from yaml import CSafeLoader
+
+            return load(yaml_file, Loader=CSafeLoader)
+        except ImportError:
+            print(
+                """Warning! PyYAML LibYAML C bindings are not installed.
+             Course loading still works, but it will be slower.
+             For more details, check https://github.com/yaml/pyyaml#Installation"""
+            )
+            from yaml import SafeLoader
+
+            return load(yaml_file, Loader=SafeLoader)
 
 
 def _convert_language(raw_language) -> Language:

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
@@ -51,7 +51,7 @@ class YamlImportTestCase(FakeFsTestCase):
 
 class TestLoadCourseMeta(YamlImportTestCase):
     def create_fake_course_meta(self, path, **kwargs):
-        with open(Path(path) / "course.yaml", "w") as f:
+        with open(Path(path) / "course.yaml", "w", encoding="utf-8") as f:
             f.write(self.get_fake_course_yaml(**kwargs))
 
     def get_fake_course_yaml(self, **kwargs):
@@ -188,7 +188,7 @@ class TestLoadCourseMeta(YamlImportTestCase):
         self.assertEqual(tts_settings_list, [])
 
     def _append_settings_to_file(self, new_settings):
-        with open(Path(self.fake_path) / "course.yaml", "a") as f:
+        with open(Path(self.fake_path) / "course.yaml", "a", encoding="utf-8") as f:
             f.write(new_settings)
 
     def test_returns_correct_settings_audio_disabled(self):
@@ -505,7 +505,7 @@ class TestLoadModuleMeta(YamlImportTestCase):
     """
 
     def create_fake_module_meta(self, path, **kwargs):
-        with open(Path(path) / "module.yaml", "w") as f:
+        with open(Path(path) / "module.yaml", "w", encoding="utf-8") as f:
             f.write(self.get_fake_module_yaml(**kwargs))
 
     def get_fake_values(self):
@@ -579,7 +579,7 @@ Mini-dictionary:
         return "<script />" + self.fake_values["introduction"]
 
     def create_fake_skill_meta(self, path, **kwargs):
-        with open(Path(path) / "food.yaml", "w") as f:
+        with open(Path(path) / "food.yaml", "w", encoding="utf-8") as f:
             f.write(self.get_fake_skill_yaml(**kwargs))
 
     def get_fake_values(self):
@@ -622,7 +622,7 @@ Mini-dictionary:
             },
         )
 
-        with open(self.fake_path / "food.md", "w") as f:
+        with open(self.fake_path / "food.md", "w", encoding="utf-8") as f:
             f.write(self.get_fake_skill_markdown())
 
         french = Language(self.fake_values["word3"], "")


### PR DESCRIPTION
By making use of CSafeLoader we require that the LibYAML C bindings of PyYAML are installed. If these bindings are not present, this commit ensures that the YAML Loader still works. However, performance will not be as good as with the C bindings.