### PR TITLE
style: remove duplicated character

### DIFF
--- a/scripts/exportYamlCourse.sh
+++ b/scripts/exportYamlCourse.sh
@@ -9,7 +9,7 @@ cd ./apps/librelingo_json_export/ ||
   exit 1
 }
 if poetry run librelingo-export-cli ../../courses/"$1" ../../apps/web/src/courses/"$1"; then
-		echo -en "\r✅ Exported course $1"
+		echo -en "\r✅ Exported course $1 "
 else
 		echo -en "\r⚠️  Couldn't export course $1"
 		exit 1

--- a/scripts/exportYamlCourse.sh
+++ b/scripts/exportYamlCourse.sh
@@ -9,7 +9,7 @@ cd ./apps/librelingo_json_export/ ||
   exit 1
 }
 if poetry run librelingo-export-cli ../../courses/"$1" ../../apps/web/src/courses/"$1"; then
-		echo -en "\r✅ Exported course $1 "
+		echo -en "\r\033[K✅ Exported course $1"
 else
 		echo -en "\r⚠️  Couldn't export course $1"
 		exit 1


### PR DESCRIPTION
By executing the command `yarn exportAllCourses` or equivalency by running `./scripts/exportAllYamlCourses.sh` one gets an output similar to
```
✅ Exported course brazilian-portuguese-from-englishh
✅ Exported course french-from-englishh
✅ Exported course german-from-englishh
✅ Exported course houma-from-englishh
✅ Exported course neolatin-from-englishh
✅ Exported course spanish-from-englishh
✅ Exported course testt
```
Note the duplicated character at the end of each line. This comes form the fact that [_exporting course message_](https://github.com/LibreLingo/LibreLingo/blob/35a0fe190e37a8c72eeb2eb18eb23886a9391388/scripts/exportYamlCourse.sh#L5) is one character longer than [_exporting is done message_](https://github.com/LibreLingo/LibreLingo/blob/35a0fe190e37a8c72eeb2eb18eb23886a9391388/scripts/exportYamlCourse.sh#L12).

This PR fixes that.
