### PR TITLE
Add initial schema validation for modules

### DIFF
--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
@@ -383,17 +383,15 @@ def _load_module(path: str, course: Course):
     filepath = Path(path) / "module.yaml"
     data = _load_yaml(filepath)
 
-    # Hardcoded is not great, should path lead to some other place?
     schemapath = "../../apps/librelingo_yaml_loader/schemas/module.json"
     with open(schemapath) as fp:
         schema = json.load(fp)
 
-    # Should I take out unnecessary exception handling below?
     try:
         jsonschema.validate(data, schema)
     except jsonschema.ValidationError as validation_error:
         raise RuntimeError(
-            f'There is an error with the schema at the following file path: {filepath}'
+            f"There is an error with the schema at the following file path: {filepath}"
         ) from validation_error
 
     try:

--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import List, Union
 
 import bleach
+import json
+import jsonschema
 import html2markdown  # type: ignore
 import markdown
 from librelingo_types import (
@@ -380,6 +382,20 @@ def _load_module(path: str, course: Course):
     """
     filepath = Path(path) / "module.yaml"
     data = _load_yaml(filepath)
+
+    # Hardcoded is not great, should path lead to some other place?
+    schemapath = "../../apps/librelingo_yaml_loader/schemas/module.json"
+    with open(schemapath) as fp:
+        schema = json.load(fp)
+
+    # Should I take out unnecessary exception handling below?
+    try:
+        jsonschema.validate(data, schema)
+    except jsonschema.ValidationError as validation_error:
+        raise RuntimeError(
+            f'There is an error with the schema at the following file path: {filepath}'
+        ) from validation_error
+
     try:
         module = data["Module"]
         skills = data["Skills"]

--- a/apps/librelingo_yaml_loader/pyproject.toml
+++ b/apps/librelingo_yaml_loader/pyproject.toml
@@ -17,6 +17,7 @@ html2markdown = "^0.1.7"
 bleach = "^5.0.0"
 bleach-whitelist = "^0.0.11"
 hunspell = { version = "^0.5.5", optional = true }
+jsonschema = "^4.17.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.0"

--- a/apps/librelingo_yaml_loader/schemas/module.json
+++ b/apps/librelingo_yaml_loader/schemas/module.json
@@ -1,0 +1,21 @@
+{
+    "type" : "object",
+    "properties" : {
+        "Module" : {
+            "type" : "object",
+            "properties" : {
+                "Name" : {
+                    "type" : "string"
+                }
+            },
+            "required": ["Name"]
+        },
+        "Skills" : {
+            "type" : "array",
+            "items" : {
+                "type" : "string"
+            }
+        }
+    },
+    "required": ["Module","Skills"]
+}


### PR DESCRIPTION
Added the jsonschema package to the project and initial schema validation logic to the yaml_loader for validating module .yaml files. Also created a schemas directory within apps/librelingo_yaml_loader and added a JSON schema to validate the format of module .yaml files.

Contributes to #2438, but there is more to be done adding the loading for courses and skills.

I had a few uncertainties with implementing these changes as follows:
- Is it alright to have schemas located in apps/librelingo_yaml_loader and is there any way to get around hard coding this path to load the schema json files from? I considered it being within the courses directory but I don't think there is a way for it to be there without duplicating the same schema file across multiple courses
- There is additional error checking in the _load_modules function I edited that I believe will become redundant with the schema validation, but I was not sure if I should remove it yet