### PR TITLE
WIP: Add Esperanto from Spanish course

### DIFF
--- a/config/courses.json
+++ b/config/courses.json
@@ -141,5 +141,16 @@
     "deploy": true,
     "devtoolsEnabled": false,
     "inProduction": false
+  },
+  {
+    "url": "https://notabug.org/jorgesumle/LibreLingo-Esperanto-from-Spanish/archive/master.zip",
+    "repositoryURL": "https://notabug.org/jorgesumle/LibreLingo-Esperanto-from-Spanish",
+    "paths": {
+      "yamlFolder": "LibreLingo-Esperanto-from-Spanish",
+      "jsonFolder": "esperanto-from-spanish"
+    },
+    "deploy": true,
+    "devtoolsEnabled": false,
+    "inProduction": false
   }
 ]


### PR DESCRIPTION
Hi, I'm translating the basic course Spanish from English into Esperanto from Spanish, but I got the following error when running `yarn exportAllCourses`:

```
 yarn exportAllCourses
yarn run v1.22.19
$ ./scripts/exportAllYamlCourses.sh
✅ Exported course basque-from-english
✅ Exported course brazilian-portuguese-from-english
⏳ Exporting course esperanto-from-spanishTraceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/jorge/.cache/pypoetry/virtualenvs/librelingo-json-export-KgEiUmpX-py3.11/lib/python3.11/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorge/.cache/pypoetry/virtualenvs/librelingo-json-export-KgEiUmpX-py3.11/lib/python3.11/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/jorge/.cache/pypoetry/virtualenvs/librelingo-json-export-KgEiUmpX-py3.11/lib/python3.11/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorge/.cache/pypoetry/virtualenvs/librelingo-json-export-KgEiUmpX-py3.11/lib/python3.11/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorge/Repositorios/LibreLingo/apps/librelingo_json_export/librelingo_json_export/cli.py", line 27, in main
    course = load_course(input_path)
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorge/.cache/pypoetry/virtualenvs/librelingo-json-export-KgEiUmpX-py3.11/lib/python3.11/site-packages/librelingo_yaml_loader/yaml_loader.py", line 496, in load_course
    modules = _load_modules(path, raw_modules, dumb_course)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorge/.cache/pypoetry/virtualenvs/librelingo-json-export-KgEiUmpX-py3.11/lib/python3.11/site-packages/librelingo_yaml_loader/yaml_loader.py", line 408, in _load_modules
    return [_load_module(Path(path) / module, course) for module in modules]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorge/.cache/pypoetry/virtualenvs/librelingo-json-export-KgEiUmpX-py3.11/lib/python3.11/site-packages/librelingo_yaml_loader/yaml_loader.py", line 408, in <listcomp>
    return [_load_module(Path(path) / module, course) for module in modules]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorge/.cache/pypoetry/virtualenvs/librelingo-json-export-KgEiUmpX-py3.11/lib/python3.11/site-packages/librelingo_yaml_loader/yaml_loader.py", line 400, in _load_module
    skills=_load_skills(path, skills, course),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorge/.cache/pypoetry/virtualenvs/librelingo-json-export-KgEiUmpX-py3.11/lib/python3.11/site-packages/librelingo_yaml_loader/yaml_loader.py", line 365, in _load_skills
    return [_load_skill(Path(path) / "skills" / skill, course) for skill in skills]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorge/.cache/pypoetry/virtualenvs/librelingo-json-export-KgEiUmpX-py3.11/lib/python3.11/site-packages/librelingo_yaml_loader/yaml_loader.py", line 365, in <listcomp>
    return [_load_skill(Path(path) / "skills" / skill, course) for skill in skills]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorge/.cache/pypoetry/virtualenvs/librelingo-json-export-KgEiUmpX-py3.11/lib/python3.11/site-packages/librelingo_yaml_loader/yaml_loader.py", line 354, in _load_skill
    dictionary=_convert_mini_dictionary(data, course)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jorge/.cache/pypoetry/virtualenvs/librelingo-json-export-KgEiUmpX-py3.11/lib/python3.11/site-packages/librelingo_yaml_loader/yaml_loader.py", line 276, in _convert_mini_dictionary
    for item in raw_mini_dictionary[language_name]:
                ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'esperanto'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

My plan is to translate the course, and later, if it works fine, add more lessons. However, I need to solve this issue, so that I can test that my course doesn't produce any errors.