### PR TITLE
pylint config: enable "invalid-name"

### DIFF
--- a/apps/librelingo_audios/librelingo_audios/update_audios.py
+++ b/apps/librelingo_audios/librelingo_audios/update_audios.py
@@ -57,8 +57,8 @@ def _load_index_file(file_path: Path):
     if not file_path.is_file():
         return []
 
-    with open(file_path, "r") as f:
-        return json.loads(f.read())
+    with open(file_path, "r") as file:
+        return json.loads(file.read())
 
 
 def _keep_phrases(phrases_to_keep: Union[Set, Set[PhraseIdentity]], existing_index):
@@ -171,9 +171,9 @@ def _delete_audio_for_phrase(index_entry, output_path: str, settings):
 
 
 def _save_index(result_index: list, index_file_path: Path):
-    with open(index_file_path, "w", encoding="utf-8") as f:
+    with open(index_file_path, "w", encoding="utf-8") as file:
         json.dump(
-            sorted(result_index, key=lambda i: i["id"]), f, ensure_ascii=False, indent=4
+            sorted(result_index, key=lambda i: i["id"]), file, ensure_ascii=False, indent=4
         )
 
 

--- a/apps/librelingo_audios/tests/conftest.py
+++ b/apps/librelingo_audios/tests/conftest.py
@@ -98,8 +98,8 @@ def aws_cli(mocker, tmp_path):
 @pytest.fixture
 def write_mock_audio_file_for_text(tmp_path):
     def write_file(text):
-        with open(tmp_path / _mock_audio_file_for_text(text), "w") as f:
-            f.write(f"this is a fake audio file for {text}")
+        with open(tmp_path / _mock_audio_file_for_text(text), "w") as file:
+            file.write(f"this is a fake audio file for {text}")
 
     return write_file
 
@@ -107,8 +107,8 @@ def write_mock_audio_file_for_text(tmp_path):
 @pytest.fixture
 def index_file(tmp_path):
     def assert_entries_match(expected_entries):
-        with open(tmp_path / "test.json", "r") as f:
-            entries = json.loads(f.read())
+        with open(tmp_path / "test.json", "r") as file:
+            entries = json.loads(file.read())
             assert entries == expected_entries
 
     def assert_exists():
@@ -118,8 +118,8 @@ def index_file(tmp_path):
         assert not list(tmp_path.iterdir())
 
     def set_entries(entries):
-        with open(tmp_path / "test.json", "w", encoding="utf-8") as f:
-            json.dump(entries, f, ensure_ascii=False, indent=4)
+        with open(tmp_path / "test.json", "w", encoding="utf-8") as file:
+            json.dump(entries, file, ensure_ascii=False, indent=4)
 
     return SimpleNamespace(
         **{

--- a/apps/librelingo_fakes/librelingo_fakes/fakes.py
+++ b/apps/librelingo_fakes/librelingo_fakes/fakes.py
@@ -49,10 +49,10 @@ from librelingo_types import (
     Word,
 )
 
-challenge1 = "challenge1"
-challenge2 = "challenge2"
-challenge3 = "challenge3"
-challenge4 = "challenge4"
+CHALLENGE1 = "CHALLENGE1"
+CHALLENGE2 = "CHALLENGE2"
+CHALLENGE3 = "CHALLENGE3"
+CHALLENGE4 = "CHALLENGE4"
 
 fake_dictionary = [
     DictionaryItem("foo", "barrus", False),

--- a/apps/librelingo_json_export/librelingo_json_export/export.py
+++ b/apps/librelingo_json_export/librelingo_json_export/export.py
@@ -31,8 +31,8 @@ def _open_output_stream(output_file_path, settings):
 
 
 def _save_as_json_file(data, output_file_path, settings):
-    with _open_output_stream(output_file_path, settings) as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
+    with _open_output_stream(output_file_path, settings) as file:
+        json.dump(data, file, ensure_ascii=False, indent=2)
 
 
 def _export_course_skills(export_path: str, course: Course, settings=DEFAULT_SETTINGS):
@@ -69,8 +69,8 @@ def _export_skill(
     if skill.introduction:
         with _open_output_stream(
             Path(export_path) / "introduction" / f"{slug}.md", settings
-        ) as f:
-            f.write(skill.introduction)
+        ) as file:
+            file.write(skill.introduction)
 
 
 def _export_course_data(export_path: str, course: Course, settings=DEFAULT_SETTINGS):

--- a/apps/librelingo_json_export/tests/test_cli.py
+++ b/apps/librelingo_json_export/tests/test_cli.py
@@ -25,12 +25,12 @@ def mocks(mocker):
 
 
 @pytest.fixture
-def invoke(mocks, fs):
-    def f(args):
+def invoke(mocks):
+    def file(args):
         runner = CliRunner()
         return runner.invoke(main, args, catch_exceptions=False)
 
-    return f
+    return file
 
 
 @pytest.fixture
@@ -39,21 +39,21 @@ def load_course_mock(mocker):
 
 
 @pytest.fixture
-def invoke_with_load_course_mock(load_course_mock, fs):
-    def f(args):
+def invoke_with_load_course_mock(load_course_mock):
+    def file(args):
         runner = CliRunner()
         return runner.invoke(main, args, catch_exceptions=False)
 
-    return f
+    return file
 
 
 @pytest.fixture
-def invoke_with_no_mocks(fs):
-    def f(args):
+def invoke_with_no_mocks():
+    def file(args):
         runner = CliRunner()
         return runner.invoke(main, args, catch_exceptions=False)
 
-    return f
+    return file
 
 
 def test_yaml_to_json_loads_correct_course(mocks, inputs, invoke):
@@ -72,7 +72,7 @@ def test_yaml_to_json_has_help_text(mocks, inputs, invoke):
     assert main.help
 
 
-def test_creates_output_directory_if_it_doesnt_exist(mocks, inputs, invoke, fs):
+def test_creates_output_directory_if_it_doesnt_exist(mocks, inputs, invoke):
     output_path = "foo/500/bar"
     invoke([inputs[0], output_path])
     assert os.path.isdir(output_path)
@@ -101,10 +101,10 @@ def test_dry_run_calls_real_export_course(mocks, inputs, invoke):
 
 
 @pytest.mark.parametrize("no_dry_run_arg", [["--no-dry-run"], []])
-def test_creates_excpected_files(fs, invoke_with_no_mocks, no_dry_run_arg):
+def test_creates_excpected_files(f_s, invoke_with_no_mocks, no_dry_run_arg):
     input_path = Path(__file__).parent / "fixtures" / "fake_course"
-    fs.add_real_directory(input_path)
-    fs.add_real_directory(os.path.dirname(jsonschema.__file__))
+    f_s.add_real_directory(input_path)
+    f_s.add_real_directory(os.path.dirname(jsonschema.__file__))
     output_path = fakes.path()
     expected_files = {
         output_path / "courseData.json",

--- a/apps/librelingo_json_export/tests/test_export_course.py
+++ b/apps/librelingo_json_export/tests/test_export_course.py
@@ -14,8 +14,7 @@ def mock_export_course_data(mocker):
     return mocker.patch("librelingo_json_export.export._export_course_data")
 
 
-def test_calls__export_course_data_with_correct_value(
-    fs, export_path, mock_export_course_data
+def test_calls__export_course_data_with_correct_value(export_path, mock_export_course_data
 ):
     export_course(export_path, fakes.course1)
     mock_export_course_data.assert_called_with(
@@ -28,8 +27,7 @@ def mock_export_course_skills(mocker):
     return mocker.patch("librelingo_json_export.export._export_course_skills")
 
 
-def test_calls__export_course_skills_with_correct_value(
-    fs, export_path, mock_export_course_skills
+def test_calls__export_course_skills_with_correct_value(export_path, mock_export_course_skills
 ):
     export_course(export_path, fakes.course1)
     mock_export_course_skills.assert_called_with(

--- a/apps/librelingo_json_export/tests/test_export_course_data.py
+++ b/apps/librelingo_json_export/tests/test_export_course_data.py
@@ -13,7 +13,7 @@ def export_path():
     return fakes.path()
 
 
-def test_creates_the_correct_file(fs, export_path):
+def test_creates_the_correct_file(export_path):
     _export_course_data(export_path, fakes.course1)
     assert os.path.exists(export_path / "courseData.json")
 
@@ -23,23 +23,22 @@ def mock_get_course_data(mocker):
     return mocker.patch("librelingo_json_export.export._get_course_data")
 
 
-def test_calls__get_course_data_with_correct_value(
-    fs, export_path, mock_get_course_data
+def test_calls__get_course_data_with_correct_value(export_path, mock_get_course_data
 ):
     mock_get_course_data.return_value = []
     _export_course_data(export_path, fakes.course1)
     mock_get_course_data.assert_called_with(fakes.course1)
 
 
-def test_writes_correct_value_into_json_file(fs, export_path, mock_get_course_data):
+def test_writes_correct_value_into_json_file(export_path, mock_get_course_data):
     fake_course_data = {"fake_course_data": 1000}
     mock_get_course_data.return_value = fake_course_data
     _export_course_data(export_path, fakes.course1)
-    with open(export_path / "courseData.json") as f:
-        assert json.loads(f.read()) == fake_course_data
+    with open(export_path / "courseData.json") as file:
+        assert json.loads(file.read()) == fake_course_data
 
 
-def test_assert_logs_correctly(caplog, fs, export_path):
+def test_assert_logs_correctly(caplog, export_path):
     with caplog.at_level(logging.INFO, logger="librelingo_json_export"):
         course_name = "Animals"
         target_name = "English"

--- a/apps/librelingo_json_export/tests/test_export_course_skills.py
+++ b/apps/librelingo_json_export/tests/test_export_course_skills.py
@@ -15,7 +15,7 @@ def mock_export_skill(mocker):
     return mocker.patch("librelingo_json_export.export._export_skill")
 
 
-def test_exports_all_skills(mocker, fs, export_path, mock_export_skill):
+def test_exports_all_skills(mocker, export_path, mock_export_skill):
     _, fake_skill_1 = fakes.get_fake_skill()
     _, fake_skill_2 = fakes.get_fake_skill()
     _, fake_skill_3 = fakes.get_fake_skill()

--- a/apps/librelingo_json_export/tests/test_export_prepare_output_path.py
+++ b/apps/librelingo_json_export/tests/test_export_prepare_output_path.py
@@ -2,10 +2,10 @@ from librelingo_json_export.export import _prepare_output_path
 from librelingo_fakes import fakes
 
 
-def test_returns_inputed_path_when_no_dry_run(fs):
+def test_returns_inputed_path_when_no_dry_run():
     output_file_path = fakes.path() / "some_file.txt"
     assert _prepare_output_path(output_file_path) == output_file_path
 
 
-def test_creates_result_path_when_no_dry_run(fs):
+def test_creates_result_path_when_no_dry_run():
     assert _prepare_output_path(fakes.path() / "some_file.txt").parent.exists()

--- a/apps/librelingo_json_export/tests/test_export_skill.py
+++ b/apps/librelingo_json_export/tests/test_export_skill.py
@@ -12,13 +12,13 @@ def export_path():
     return fakes.path()
 
 
-def test_creates_the_challenges_file(fs, export_path):
+def test_creates_the_challenges_file(export_path):
     random_name, fake_skill = fakes.get_fake_skill()
     _export_skill(export_path, fake_skill, fakes.course1)
     assert os.path.exists(export_path / "challenges" / f"animals-{random_name}.json")
 
 
-def test_creates_the_introduction_file(fs, export_path):
+def test_creates_the_introduction_file(export_path):
     fake_name = str(fakes.fake_value())
     introduction = f"# *Hello* (https://example.com)[_{fake_name}_]!"
     random_name, fake_skill = fakes.get_fake_skill(introduction=introduction)
@@ -30,8 +30,7 @@ def test_creates_the_introduction_file(fs, export_path):
         assert introduction_file_content == introduction
 
 
-def test_does_not_create_an_introduction_file_if_theres_no_introduction(
-    fs, export_path
+def test_does_not_create_an_introduction_file_if_theres_no_introduction(export_path
 ):
     random_name, fake_skill = fakes.get_fake_skill()
     _export_skill(export_path, fake_skill, fakes.course1)
@@ -45,13 +44,13 @@ def mock_get_skill_data(mocker):
     return mocker.patch("librelingo_json_export.export._get_skill_data")
 
 
-def test_calls__get_skill_data_with_correct_value(fs, export_path, mock_get_skill_data):
+def test_calls__get_skill_data_with_correct_value(export_path, mock_get_skill_data):
     mock_get_skill_data.return_value = []
     _export_skill(export_path, fakes.skillWithPhraseAndWord, fakes.course1)
     mock_get_skill_data.assert_called_with(fakes.skillWithPhraseAndWord, fakes.course1)
 
 
-def test_writes_correct_value_into_json_file(fs, export_path, mock_get_skill_data):
+def test_writes_correct_value_into_json_file(export_path, mock_get_skill_data):
     fake_skill_data = {"fake_skill_data": 1000}
     mock_get_skill_data.return_value = fake_skill_data
     _export_skill(export_path, fakes.skillWithPhraseAndWord, fakes.course1)
@@ -59,7 +58,7 @@ def test_writes_correct_value_into_json_file(fs, export_path, mock_get_skill_dat
         assert json.loads(masculine_file.read()) == fake_skill_data
 
 
-def test_assert_logs_correctly(fs, caplog, export_path):
+def test_assert_logs_correctly(caplog, export_path):
     with caplog.at_level(logging.INFO, logger="librelingo_json_export"):
         _, fake_skill = fakes.get_fake_skill()
         _export_skill(export_path, fake_skill, fakes.course1)

--- a/apps/librelingo_json_export/tests/test_integration.py
+++ b/apps/librelingo_json_export/tests/test_integration.py
@@ -10,15 +10,15 @@ from librelingo_yaml_loader import load_course
 
 
 def read_json_file(path):
-    with open(path) as fp:
-        return json.load(fp)
+    with open(path) as f_p:
+        return json.load(f_p)
 
 
-def test_loaded_yaml_is_exported_to_correct_json(fs, snapshot):
+def test_loaded_yaml_is_exported_to_correct_json(f_s, snapshot):
     fixture_path = os.path.join(os.path.dirname(__file__), "fixtures", "fake_course")
-    fs.add_real_directory(fixture_path)
-    fs.add_real_directory(os.path.dirname(jsonschema.__file__))
-    fs.create_dir("output")
+    f_s.add_real_directory(fixture_path)
+    f_s.add_real_directory(os.path.dirname(jsonschema.__file__))
+    f_s.create_dir("output")
     course = load_course(fixture_path)
     export_course("./output", course)
     files = glob.glob("./output/**/*")
@@ -29,5 +29,5 @@ def test_loaded_yaml_is_exported_to_correct_json(fs, snapshot):
         for fname in files
     }
 
-    fs.pause()  # Write snapshots to the real fs, not the fake
+    f_s.pause()  # Write snapshots to the real f_s, not the fake
     snapshot.assert_match(data)

--- a/apps/librelingo_json_export/tests/test_skills_get_skill_data.py
+++ b/apps/librelingo_json_export/tests/test_skills_get_skill_data.py
@@ -22,10 +22,10 @@ def mock_get_challenges_data(mocker):
 
 
 def test_correct_number_of_levels(mock_calculate_number_of_levels):
-    FAKE_NUMBER = "fake number"
-    mock_calculate_number_of_levels.return_value = FAKE_NUMBER
+    fake_number = "fake_number"
+    mock_calculate_number_of_levels.return_value = fake_number
     converted_skill = _get_skill_data(fakes.emptySkill, fakes.course1)
-    assert converted_skill["levels"] == FAKE_NUMBER
+    assert converted_skill["levels"] == fake_number
 
 
 def test_calculates_levels_correctly(mock_calculate_number_of_levels):
@@ -34,10 +34,10 @@ def test_calculates_levels_correctly(mock_calculate_number_of_levels):
 
 
 def test_correct_challenges(mock_get_challenges_data):
-    FAKE_CHALLENGES = "fake challenges"
-    mock_get_challenges_data.return_value = FAKE_CHALLENGES
+    fake_challenges = "fake_challenges"
+    mock_get_challenges_data.return_value = fake_challenges
     converted_skill = _get_skill_data(fakes.skills[1], fakes.course1)
-    assert converted_skill["challenges"] == FAKE_CHALLENGES
+    assert converted_skill["challenges"] == fake_challenges
 
 
 def test_formats_challenges_correctly(mock_get_challenges_data):

--- a/apps/librelingo_utils/librelingo_utils/utils.py
+++ b/apps/librelingo_utils/librelingo_utils/utils.py
@@ -44,10 +44,10 @@ def clean_word(word: Word):
     """
     Remove punctuation and other special characters from a word.
     """
-    MATCH_NON_WORD_CHARACTERS_BEGINNING = regex.compile("^[^\\w']+")
-    MATCH_NON_WORD_CHARACTERS_END = regex.compile("[^\\w']+$")
-    return MATCH_NON_WORD_CHARACTERS_BEGINNING.sub(
-        "", MATCH_NON_WORD_CHARACTERS_END.sub("", word)
+    match_non_word_characters_beginning = regex.compile("^[^\\w']+")
+    match_non_word_characters_end = regex.compile("[^\\w']+$")
+    return match_non_word_characters_beginning.sub(
+        "", match_non_word_characters_end.sub("", word)
     )
 
 

--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/_spelling.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/_spelling.py
@@ -1,6 +1,6 @@
 from librelingo_types.data_types import HunspellSettings
 
-hunspell = None  # Needed so that hunspell can be mocked
+HUNSPELL = None  # Needed so that hunspell can be mocked
 
 
 def _validate_word_in_source_language(word, course):
@@ -64,18 +64,17 @@ def _run_skill_spellcheck(phrases, words, course):
 
 
 def _convert_hunspell_settings_for_language(raw_language_name):
+    global HUNSPELL
+    language_code = raw_language_name
+    if not HUNSPELL:
+        HUNSPELL = HUNSPELL.HunSpell(
+            f"/usr/share/hunspell/{language_code}.dic",
+            f"/usr/share/hunspell/{language_code}.aff",
+        )
+
     language_code = raw_language_name.replace("-", "_")
 
-    # Only import hunspell if actually needed. Still allow mocking it.
-    global hunspell
-    if not hunspell:
-        import hunspell  # type: ignore # pylint: disable=import-error
-
-    return hunspell.HunSpell(
-        f"/usr/share/hunspell/{language_code}.dic",
-        f"/usr/share/hunspell/{language_code}.aff",
-    )
-
+    return HUNSPELL
 
 def _convert_hunspell_settings(raw_settings, course):
     if "Hunspell" not in raw_settings:

--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
@@ -310,8 +310,8 @@ def _load_introduction(path: str) -> Union[str, None]:
     if not os.path.exists(path):
         return None
 
-    with open(path, encoding="utf-8") as f:
-        return _sanitize_markdown(f.read())
+    with open(path, encoding="utf-8") as file:
+        return _sanitize_markdown(file.read())
 
 
 def _load_skill(path: Path, course: Course) -> Skill:

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader.py
@@ -57,8 +57,8 @@ class YamlImportTestCase(FakeFsTestCase):
 
 class TestLoadCourseMeta(YamlImportTestCase):
     def create_fake_course_meta(self, path, **kwargs):
-        with open(Path(path) / "course.yaml", "w", encoding="utf-8") as f:
-            f.write(self.get_fake_course_yaml(**kwargs))
+        with open(Path(path) / "course.yaml", "w", encoding="utf-8") as file:
+            file.write(self.get_fake_course_yaml(**kwargs))
 
     def get_fake_course_yaml(self, **kwargs):
         return f"""
@@ -194,8 +194,8 @@ class TestLoadCourseMeta(YamlImportTestCase):
         self.assertEqual(tts_settings_list, [])
 
     def _append_settings_to_file(self, new_settings):
-        with open(Path(self.fake_path) / "course.yaml", "a", encoding="utf-8") as f:
-            f.write(new_settings)
+        with open(Path(self.fake_path) / "course.yaml", "a", encoding="utf-8") as file:
+            file.write(new_settings)
 
     def test_returns_correct_settings_audio_disabled(self):
         self._append_settings_to_file(
@@ -338,10 +338,10 @@ class TestLoadCourseMeta(YamlImportTestCase):
         self.assertEqual(self.result.repository_url, self.fake_values["repository_url"])
 
 
-def test_load_course_output_matches_value(fs):
+def test_load_course_output_matches_value(f_s):
     fixture_path = os.path.join(os.path.dirname(__file__), "fixtures", "fake_course")
-    fs.add_real_directory(os.path.dirname(jsonschema.__file__))
-    fs.add_real_directory(fixture_path)
+    f_s.add_real_directory(os.path.dirname(jsonschema.__file__))
+    f_s.add_real_directory(fixture_path)
     result = load_course(fixture_path)
     assert result.target_language == Language(name="French", code="fr")
     assert result.source_language == Language(name="English", code="en")
@@ -512,8 +512,8 @@ class TestLoadModuleMeta(YamlImportTestCase):
     """
 
     def create_fake_module_meta(self, path, **kwargs):
-        with open(Path(path) / "module.yaml", "w", encoding="utf-8") as f:
-            f.write(self.get_fake_module_yaml(**kwargs))
+        with open(Path(path) / "module.yaml", "w", encoding="utf-8") as file:
+            file.write(self.get_fake_module_yaml(**kwargs))
 
     def get_fake_values(self):
         return {
@@ -586,8 +586,8 @@ Mini-dictionary:
         return "<script />" + self.fake_values["introduction"]
 
     def create_fake_skill_meta(self, path, **kwargs):
-        with open(Path(path) / "food.yaml", "w", encoding="utf-8") as f:
-            f.write(self.get_fake_skill_yaml(**kwargs))
+        with open(Path(path) / "food.yaml", "w", encoding="utf-8") as file:
+            file.write(self.get_fake_skill_yaml(**kwargs))
 
     def get_fake_values(self):
         return {
@@ -629,8 +629,8 @@ Mini-dictionary:
             },
         )
 
-        with open(self.fake_path / "food.md", "w", encoding="utf-8") as f:
-            f.write(self.get_fake_skill_markdown())
+        with open(self.fake_path / "food.md", "w", encoding="utf-8") as file:
+            file.write(self.get_fake_skill_markdown())
 
         french = Language(self.fake_values["word3"], "")
         english = Language("English", "")

--- a/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py
+++ b/apps/librelingo_yaml_loader/tests/test_yaml_loader_load_skills.py
@@ -14,12 +14,12 @@ def mock_load_skill(mocker):
     yield mocker.patch("librelingo_yaml_loader.yaml_loader._load_skill")
 
 
-def test_returns_correct_value(fs, mock_load_skill):
+def test_returns_correct_value(mock_load_skill):
     mock_load_skill.return_value = fakes.fake_value()
     assert _load_skills("foo", ["bar"], fakes.course1) == [mock_load_skill.return_value]
 
 
-def test_handles_every_module(fs, mock_load_skill):
+def test_handles_every_module(mock_load_skill):
     mock_load_skill.return_value = fakes.fake_value()
     assert (
         _load_skills("foo", ["bar", "baz"], fakes.course1)
@@ -27,6 +27,6 @@ def test_handles_every_module(fs, mock_load_skill):
     )
 
 
-def test_calls_load_skills_with_correct_arguments(fs, mock_load_skill):
+def test_calls_load_skills_with_correct_arguments(mock_load_skill):
     _load_skills("foo", ["bar.yaml"], fakes.course1)
     mock_load_skill.assert_called_with(Path("foo/skills/bar.yaml"), fakes.course1)

--- a/apps/tools/librelingo_tools/generate.py
+++ b/apps/tools/librelingo_tools/generate.py
@@ -14,9 +14,9 @@ from jinja2 import Environment, FileSystemLoader
 import lili
 
 
-def myconverter(o):
-    if isinstance(o, datetime.datetime):
-        return str(o)
+def myconverter(o_o):
+    if isinstance(o_o, datetime.datetime):
+        return str(o_o)
     return None
 
 
@@ -44,8 +44,8 @@ def generate_history_html(history, outdir):
         title="LibreLingo history",
     )
 
-    with open(os.path.join(outdir, "history.html"), "w") as fh:
-        fh.write(html)
+    with open(os.path.join(outdir, "history.html"), "w") as f_h:
+        f_h.write(html)
 
 
 def generate_index_html(start_time, end_time, links, outdir):
@@ -57,8 +57,8 @@ def generate_index_html(start_time, end_time, links, outdir):
         title="LibreLingo courses",
     )
 
-    with open(os.path.join(outdir, "index.html"), "w") as fh:
-        fh.write(html)
+    with open(os.path.join(outdir, "index.html"), "w") as f_h:
+        f_h.write(html)
 
 
 def download_course(url, tempdir):
@@ -66,13 +66,13 @@ def download_course(url, tempdir):
     res = requests.get(url, stream=True, timeout=5)
     filename = os.path.join(tempdir.name, "course.zip")
     if res.status_code == 200:
-        with open(filename, "wb") as fh:
+        with open(filename, "wb") as f_h:
             # res.raw.decode_content
-            shutil.copyfileobj(res.raw, fh)
+            shutil.copyfileobj(res.raw, f_h)
 
     # unzip
-    zf = zipfile.ZipFile(filename)
-    zf.extractall(path=tempdir.name)
+    z_f = zipfile.ZipFile(filename)
+    z_f.extractall(path=tempdir.name)
 
 
 def generate_course(links, courses_data, reldir, outdir, tdir, course_dir):
@@ -85,8 +85,8 @@ def generate_course(links, courses_data, reldir, outdir, tdir, course_dir):
     course = lili.load_course(course_dir)
     target, source, count = lili.collect_data(course)
     lili.export_to_html(course, target, source, count, reldir, docs_dir)
-    with open(os.path.join(docs_dir, "course.json")) as fh:
-        count = json.load(fh)
+    with open(os.path.join(docs_dir, "course.json")) as f_h:
+        count = json.load(f_h)
     # except Exception as err:
     #    logging.error("Failed to generate course in %s. Exception %s", course_dir, err)
     #    return None
@@ -101,23 +101,23 @@ def generate_course(links, courses_data, reldir, outdir, tdir, course_dir):
         "source_phrases": count["source_phrases"],
     }
     links.append(results)
-    with open(os.path.join(outdir, tdir, "course.json")) as fh:
-        courses_data[tdir] = json.load(fh)
+    with open(os.path.join(outdir, tdir, "course.json")) as f_h:
+        courses_data[tdir] = json.load(f_h)
 
 
 def save_history(history_file, start_time, courses_data, outdir):
-    with open(history_file, "a") as fh:
+    with open(history_file, "a") as f_h:
         json.dump(
             {"courses": courses_data, "date": start_time},
-            fh,
+            f_h,
             sort_keys=True,
             default=myconverter,
         )
-        fh.write("\n")
+        f_h.write("\n")
     shutil.copy(history_file, os.path.join(outdir, "history.json"))
     history = []
-    with open(history_file) as fh:
-        for line in fh:
+    with open(history_file) as f_h:
+        for line in f_h:
             res = json.loads(line)
             history.append(res)
     generate_history_html(history, outdir)
@@ -134,8 +134,8 @@ def main():
 
     tempdir = tempfile.TemporaryDirectory()
     start_time = datetime.datetime.now()
-    with open(courses_file) as fh:
-        courses = json.load(fh)
+    with open(courses_file) as f_h:
+        courses = json.load(f_h)
 
     logging.info("The temporary directory: %s", tempdir.name)
 
@@ -174,8 +174,8 @@ def main():
         )
 
     end_time = datetime.datetime.now()
-    with open(os.path.join(outdir, "courses.json"), "w") as fh:
-        json.dump(courses_data, fh, sort_keys=True)
+    with open(os.path.join(outdir, "courses.json"), "w") as f_h:
+        json.dump(courses_data, f_h, sort_keys=True)
     if args.history:
         save_history(args.history, start_time, courses_data, outdir)
     generate_index_html(start_time, end_time, links, outdir)

--- a/apps/tools/librelingo_tools/lili.py
+++ b/apps/tools/librelingo_tools/lili.py
@@ -112,8 +112,8 @@ def export_main_html_page(course, count, reldir, html_dir):
         course=course,
         count=count,
     )
-    with open(os.path.join(html_dir, "index.html"), "w") as fh:
-        fh.write(html)
+    with open(os.path.join(html_dir, "index.html"), "w") as f_h:
+        f_h.write(html)
 
     html = render(
         "converter.html",
@@ -122,8 +122,8 @@ def export_main_html_page(course, count, reldir, html_dir):
         rel="",
         course=course,
     )
-    with open(os.path.join(html_dir, "converter.html"), "w") as fh:
-        fh.write(html)
+    with open(os.path.join(html_dir, "converter.html"), "w") as f_h:
+        f_h.write(html)
 
     html = render(
         "modules.html",
@@ -135,8 +135,8 @@ def export_main_html_page(course, count, reldir, html_dir):
         course=course,
         repository_url=get_repository_url(course),
     )
-    with open(os.path.join(html_dir, "modules.html"), "w") as fh:
-        fh.write(html)
+    with open(os.path.join(html_dir, "modules.html"), "w") as f_h:
+        f_h.write(html)
 
     html = render(
         "missing_words.html",
@@ -145,8 +145,8 @@ def export_main_html_page(course, count, reldir, html_dir):
         rel="",
         course=course,
     )
-    with open(os.path.join(html_dir, "words.html"), "w") as fh:
-        fh.write(html)
+    with open(os.path.join(html_dir, "words.html"), "w") as f_h:
+        f_h.write(html)
 
 
 def export_skill_html_pages(course, html_dir):
@@ -170,8 +170,8 @@ def export_skill_html_pages(course, html_dir):
             if not os.path.exists(dir_path):
                 os.makedirs(dir_path)
             # filename = skillurl_filter(skill.filename)
-            with open(os.path.join(dir_path, file_name + ".html"), "w") as fh:
-                fh.write(html)
+            with open(os.path.join(dir_path, file_name + ".html"), "w") as f_h:
+                f_h.write(html)
 
 
 def collect_phrases(course):
@@ -212,8 +212,8 @@ def collect_words(language, direction):
 
 
 def export_json(all_words, filename, html_dir):
-    with open(os.path.join(html_dir, filename), "w") as fh:
-        json.dump(all_words, fh)
+    with open(os.path.join(html_dir, filename), "w") as f_h:
+        json.dump(all_words, f_h)
 
 
 def export_words_html_page(course, all_words, language, path, reldir, html_file):
@@ -230,8 +230,8 @@ def export_words_html_page(course, all_words, language, path, reldir, html_file)
         dictionary=language["dictionary"],
         phrases=language["phrases"],
     )
-    with open(html_file, "w") as fh:
-        fh.write(html)
+    with open(html_file, "w") as f_h:
+        f_h.write(html)
 
     #    word_class = ""
     #    if len(words[word]) > 1:
@@ -273,8 +273,8 @@ def export_word_html_pages(course, all_words, language, reldir, words_dir):
             branch=branch,
             course=course,
         )
-        with open(os.path.join(words_dir, target_word.lower() + ".html"), "w") as fh:
-            fh.write(html)
+        with open(os.path.join(words_dir, target_word.lower() + ".html"), "w") as f_h:
+            f_h.write(html)
 
 
 def export_to_html(course, target, source, count, reldir, html_dir):
@@ -329,8 +329,8 @@ def export_to_html(course, target, source, count, reldir, html_dir):
     export_word_html_pages(
         course, all_source_words, source, reldir, os.path.join(html_dir, "source")
     )
-    with open(os.path.join(html_dir, "course.json"), "w") as fh:
-        json.dump(count, fh)
+    with open(os.path.join(html_dir, "course.json"), "w") as f_h:
+        json.dump(count, f_h)
 
 
 def clean(text):

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
     "jest": "jest src",
     "types": "sapper build && tsc && svelte-check --treshold error",
     "installCourse": "./scripts/installExternalCourse.sh",
-    "installAllExternalCourses": "python ./scripts/installExternalCourses.py ../../config/courses.json",
+    "installAllExternalCourses": "python3 ./scripts/installExternalCourses.py ../../config/courses.json",
     "fetchPhotos": "./scripts/fetchPhotos.sh",
     "fetchAudios": "./scripts/fetchAudios.sh",
     "percypress": "bash ./percypress.sh",

--- a/apps/web/scripts/installExternalCourses.py
+++ b/apps/web/scripts/installExternalCourses.py
@@ -7,8 +7,8 @@ def main():
     if len(sys.argv) != 2:
         sys.exit(f"Usage: {sys.argv[0]} PATH_TO_CONFIG_FILE")
     config_filename = sys.argv[1]
-    with open(config_filename) as fh:
-        config = json.load(fh)
+    with open(config_filename) as f_h:
+        config = json.load(f_h)
 
     for course in config:
         if course["deploy"]:

--- a/pylintrc
+++ b/pylintrc
@@ -84,7 +84,7 @@ disable=raw-checker-failed,
         file-ignored,
         suppressed-message,
         useless-suppression,
-        invalid-name,  # TODO: enable
+      ;   invalid-name,  # TODO: enable
         missing-function-docstring,  # TODO: enable
         redefined-outer-name,  # TODO: enable
         missing-class-docstring,  # TODO: enable


### PR DESCRIPTION
I went through and corrected all but 2 errors on the invalid-name Pylint. The two that remain are related to changing 2 file names to snake-case, but I believe that changes critical access information, so I chose to wait on those.

I tested my implementation manually and locally, and did not write any new tests. I also commented out the invalid-name portion of the Pylint ignore file and did not delete it, so it could be referenced easily.

This is related to and fixes "Pylint config: enable "invalid-name" #1928"