### PR TITLE
chore: exclude `node_modules` from `PYTHON_FILEPATHS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON_FILEPATHS = `(find . -iname "*.py" -not -path "./.venv/*")`
+PYTHON_FILEPATHS = `(find . -iname "*.py" -not -path "./.venv/*" -not -path "./node_modules/*")`
 lint: ## Lint codebase
 	poetry run pylint --rcfile=pylintrc $(PYTHON_FILEPATHS)
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ format: ## Run black formatter
 format-fix: ## Run black formatter with automated fix
 	poetry run black $(PYTHON_FILEPATHS)
 
-type-check: ## Run black formatter with automated fix
+type-check: ## Run mypy
 	poetry run mypy $(PYTHON_FILEPATHS)
 
 pycache-delete: ## Delete the __pycache__ folders


### PR DESCRIPTION
[`Makefile`](https://github.com/LibreLingo/LibreLingo/blob/9decb515065e7d99121e26b70a54b706ca77cf91/Makefile) runs commands on all `*.py` files, including the ones in `node_modules`.

This PR excludes `node_modules` from the search and updates the explanation of the [`check-type`](https://github.com/LibreLingo/LibreLingo/blob/9decb515065e7d99121e26b70a54b706ca77cf91/Makefile#L11) command.