### PR TITLE
feat(yaml-loader): load modules concurrently using threads

### DIFF
--- a/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
+++ b/apps/librelingo_yaml_loader/librelingo_yaml_loader/yaml_loader.py
@@ -3,6 +3,7 @@ import logging
 import collections
 import os
 import re
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import List, Union
 import importlib.resources
@@ -447,7 +448,11 @@ def _load_modules(path: str, modules, course: Course):
     """
     Load each YAML module specified in the list
     """
-    return [_load_module(Path(path) / module, course) for module in modules]
+    with ThreadPoolExecutor(max_workers=os.cpu_count()) as pool:
+        futures = [
+            pool.submit(_load_module, Path(path) / module, course) for module in modules
+        ]
+        return [future.result() for future in futures]
 
 
 def _convert_license(raw_license):


### PR DESCRIPTION
Resurrected PR from #2313

The error on that PR was coming from opening file descriptors in a multiprocessing environment that were not available afterwards for the original process. By using threads we can make the loading concurrent, but I am not sure if this will actually improve loading time.