### PR TITLE
omnilingo broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ LibreLingo is licensed under the AGPL-3.0 license. In addition, course content a
 
 
 ## See also
-* [omnilingo](https://omnilingo.xyz/), listening-based language learning
+* [omnilingo](https://github.com/omnilingo/omnilingo), listening-based language learning
 
 
 ## Donate


### PR DESCRIPTION
Fixes #3029 
Changed omnilingo broken Link to its original repository.