### PR TITLE
Use local packages in pyproject.toml

### DIFF
--- a/apps/librelingo_audios/pyproject.toml
+++ b/apps/librelingo_audios/pyproject.toml
@@ -7,12 +7,12 @@ license = "GPLv3"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-librelingo-yaml-loader = "^1.12.0"
-librelingo-utils = "^2.4.0"
+librelingo-yaml-loader = { path = "../librelingo_yaml_loader/", develop = true }
+librelingo-utils = { path = "../librelingo_utils/", develop = true }
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.0"
-librelingo-fakes = "^3.2.0"
+librelingo-fakes = { path = "../librelingo_fakes/", develop = true }
 pytest-mock = "^3.5.1"
 
 [build-system]

--- a/apps/librelingo_fakes/pyproject.toml
+++ b/apps/librelingo_fakes/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-librelingo-types = "^3.0.0"
+librelingo-types = { path = "../librelingo_types/", develop = true }
 
 [tool.poetry.dev-dependencies]
 pydoc-markdown = "^4.0.0"

--- a/apps/librelingo_json_export/pyproject.toml
+++ b/apps/librelingo_json_export/pyproject.toml
@@ -11,13 +11,13 @@ librelingo-export-cli = 'librelingo_json_export.cli:main'
 
 [tool.poetry.dependencies]
 python = "^3.8"
-librelingo-types = "^3.0.0"
-librelingo-utils = "^2.6.2"
+librelingo-types = { path = "../librelingo_types/", develop = true }
+librelingo-utils = { path = "../librelingo_utils/", develop = true }
 python-slugify = "^8.0.0"
 editdistance = "^0.6.0"
 hunspell = { version = "^0.5.5", optional = true }
 click = "^7.0.0"
-librelingo-yaml-loader = "^1.12.0"
+librelingo-yaml-loader = { path = "../librelingo_yaml_loader/", develop = true }
 
 [tool.poetry.dev-dependencies]
 pyfakefs = "^5.0.0"

--- a/apps/librelingo_utils/pyproject.toml
+++ b/apps/librelingo_utils/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-librelingo-types = "^3.0.0"
+librelingo-types = { path = "../librelingo_types/", develop = true }
 regex = "^2023.0.0"
 
 [tool.poetry.dev-dependencies]

--- a/apps/librelingo_yaml_loader/pyproject.toml
+++ b/apps/librelingo_yaml_loader/pyproject.toml
@@ -12,7 +12,7 @@ pyfakefs = "^5.0.0"
 pyyaml = "^6.0.0"
 snapshottest = "^0.6.0"
 click = "^7.0.0"
-librelingo-types = "^3.3.0"
+librelingo-types = { path = "../librelingo_types/", develop = true }
 Markdown = "^3.3.4"
 html2markdown = "^0.1.7"
 bleach = "^6.0.0"
@@ -25,7 +25,7 @@ pytest = "^7.0.0"
 pytest-watch = "^4.2.0"
 pylint = "^2.6.0"
 pytest-mock = "^3.5.0"
-librelingo-fakes = "^3.2.0"
+librelingo-fakes = { path = "../librelingo_fakes/", develop = true }
 pydoc-markdown = ">=4.0.0,<5.0.0"
 
 

--- a/apps/tools/pyproject.toml
+++ b/apps/tools/pyproject.toml
@@ -8,8 +8,8 @@ authors = ["Your Name <you@example.com>"]
 python = "^3.8"
 requests = "^2.26.0"
 Jinja2 = "^3.0.3"
-librelingo-json-export = "^0.11.0"
-librelingo-yaml-loader = "^1.12.0"
+librelingo-json-export = { path = "../librelingo_json_export/", develop = true }
+librelingo-yaml-loader = { path = "../librelingo_yaml_loader/", develop = true }
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Using local packages instead of versioned pypi packages allows for instant updates to sub-packages without needing to create a new release. Packages can now be installed with one `poetry install` command in the root librelingo project.

Version drift between sub-packages is also stopped. It's impossible for librelingo-json-export and librelingo-yaml-loader to depend on different versions of librelingo-fakes.

https://github.com/LibreLingo/LibreLingo/issues/3023

https://github.com/LibreLingo/LibreLingo/issues/2763